### PR TITLE
chore: Use Identifable where possible

### DIFF
--- a/src/ansys/simai/core/data/projects.py
+++ b/src/ansys/simai/core/data/projects.py
@@ -123,10 +123,10 @@ class ProjectDirectory(Directory[Project]):
         else:
             raise InvalidArguments("Either name or id argument should be specified")
 
-    def delete(self, id: str) -> None:
+    def delete(self, project: Identifiable[Project]) -> None:
         """Deletes a project.
 
         Args:
-            id: The id of the project to delete
+            project: The id or :class:`model <Project>` of the project to delete
         """
-        self._client._api.delete_project(id)
+        self._client._api.delete_project(get_id_from_identifiable(project))

--- a/src/ansys/simai/core/data/types.py
+++ b/src/ansys/simai/core/data/types.py
@@ -248,15 +248,19 @@ def get_id_from_identifiable(
     elif default:
         return get_id_from_identifiable(default, required)
     elif required:
-        raise InvalidArguments(f"Argument {identifiable} is neither a model nor an id string.")
+        raise InvalidArguments(f"Argument {identifiable} is neither a data model nor an id string.")
 
 
 def get_object_from_identifiable(
-    identifiable: Identifiable[DataModelType], directory: Directory
+    identifiable: Optional[Identifiable],
+    directory: Directory,
+    default: Optional[Identifiable] = None,
 ) -> DataModel:
     if isinstance(identifiable, DataModel):
         return identifiable
     elif isinstance(identifiable, str):
         return directory.get(id=identifiable)
+    elif default:
+        return get_object_from_identifiable(default, directory)
     else:
-        raise InvalidArguments(f"Argument {identifiable} is neither a model nor an id string.")
+        raise InvalidArguments(f"Argument {identifiable} is neither a data model nor an id string.")

--- a/src/ansys/simai/core/data/workspaces.py
+++ b/src/ansys/simai/core/data/workspaces.py
@@ -24,7 +24,7 @@ from pprint import pformat
 from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 from ansys.simai.core.data.base import DataModel, Directory
-from ansys.simai.core.data.types import File
+from ansys.simai.core.data.types import File, Identifiable, get_id_from_identifiable
 
 
 class ModelManifest:
@@ -172,11 +172,10 @@ class WorkspaceDirectory(Directory[Workspace]):
         """
         return self._model_from(self._client._api.create_workspace(name, model_id))
 
-    def delete(self, workspace_id) -> None:
+    def delete(self, workspace: Identifiable[Workspace]) -> None:
         """Deletes a workspace.
 
         Args:
-            workspace_id: the id of the workspace to delete
+            workspace: the id or :class:`model <Workspace>` of the workspace to delete
         """
-        self._client._api.delete_workspace(workspace_id)
-        return None
+        self._client._api.delete_workspace(get_id_from_identifiable(workspace))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,8 +185,8 @@ def project_factory(simai_client) -> Project:
 
 
 @pytest.fixture()
-def geometry_directory():
-    yield GeometryDirectory(client=None)
+def geometry_directory(simai_client):
+    yield GeometryDirectory(client=simai_client)
 
 
 @pytest.fixture()


### PR DESCRIPTION
The `Identifiable` type/utility was introduced later in the development of the SDK and it's not been applied everywhere yet, this fixes that.