### PR TITLE
Fix arguments ignored if no config file found

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+0.1.3 (2024-02-02)
+******************
+
+Fix config args not taken into account if a config file is not found
+
 0.1.2 (2024-01-24)
 ******************
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ansys-simai-core"
-version = "0.1.2"
+version = "0.1.3"
 description = "A python wrapper for Ansys SimAI"
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},
@@ -170,4 +170,3 @@ source = ["ansys.simai.core"]
 
 [tool.coverage.report]
 show_missing = true
-

--- a/src/ansys/simai/core/utils/config_file.py
+++ b/src/ansys/simai/core/utils/config_file.py
@@ -88,7 +88,7 @@ def get_config(
     config_path = path or _scan_defaults_config_paths()
     if config_path is None:
         if ignore_missing:
-            return {}
+            return kwargs
         raise ConfigurationNotFoundError
     config_path = Path(config_path).expanduser()
     if not os.path.isfile(config_path):

--- a/tests/test_utils_config.py
+++ b/tests/test_utils_config.py
@@ -49,3 +49,12 @@ def test_get_config_invalid_profile(tmpdir):
         f.flush()
         with pytest.raises(err.InvalidConfigurationError):
             get_config(profile="kaboom", path=path_config)
+
+
+def test_get_config_ignore_missing(mocker):
+    mocker.patch(
+        "ansys.simai.core.utils.config_file._scan_defaults_config_paths",
+        return_value=None,
+    )
+    config = get_config(ignore_missing=True, organization="kangarooooo")
+    assert config == {"organization": "kangarooooo"}


### PR DESCRIPTION
[sc-16887]
When using `from_config` and no config file is found, but kwargs were passed, we should not throw them away.