### PR TITLE
Less verbose SSE disconnects

### DIFF
--- a/src/ansys/simai/core/utils/sse_client.py
+++ b/src/ansys/simai/core/utils/sse_client.py
@@ -76,8 +76,8 @@ class ReconnectingSSERequestsClient:
                 requests.exceptions.ChunkedEncodingError,
                 requests.RequestException,
                 EOFError,
-            ):
-                logger.info("SSEClient disconnected ", exc_info=True)
+            ) as e:
+                logger.info(f"SSEClient disconnected: {e}")
                 logger.info(f"Will try to reconnect after {self._retry_timeout_sec}s")
                 time.sleep(self._retry_timeout_sec)
                 self._connect()


### PR DESCRIPTION
There are many reasons for SSE disconnects. While it's good to inform the user, printing a traceback is just too much !