### PR TITLE
Introduce non-interactive mode

### DIFF
--- a/doc/source/user_guide/configuration.rst
+++ b/doc/source/user_guide/configuration.rst
@@ -35,6 +35,8 @@ class:
   :model-show-validator-summary: False
   :model-show-json: False
   :model-show-field-summary: False
+  :model-show-validator-members: False
+  :field-list-validators: False
 
 
 Credentials
@@ -43,7 +45,7 @@ Credentials
 To use the SimAI API, your :class:`~ansys.simai.core.client.SimAIClient`
 instance must be authenticated. By default, you are prompted to log in
 via your web browser. However, you can pass your credentials as parameters
-on client creation:
+on client creation in the interactive mode (see `Interactive mode`_.):
 
 .. code-block:: python
 
@@ -66,4 +68,21 @@ class:
 .. autopydantic_model:: Credentials
   :model-show-config-summary: False
   :model-show-validator-summary: False
+  :model-show-validator-members: False
   :model-show-json: False
+  :field-list-validators: False
+
+.. _Interactive mode:
+
+Interactive mode
+------------------
+
+When the property `interactive` is set to `true`, the users could enter configuration
+properties from the terminal as they get prompted.
+When the property is `false`, the interactive mode is disabled, and errors would be raised
+in case of missing configuration properties.
+Default behavior is `interactive=true`.
+
+It is important to note that credentials become required when `interactive=false`.
+This means that if the credentials are missing, the users won't be prompted to enter them
+from the terminal, and an error would be raised instead.

--- a/doc/source/user_guide/configuration.rst
+++ b/doc/source/user_guide/configuration.rst
@@ -45,7 +45,7 @@ Credentials
 To use the SimAI API, your :class:`~ansys.simai.core.client.SimAIClient`
 instance must be authenticated. By default, you are prompted to log in
 via your web browser. However, you can pass your credentials as parameters
-on client creation in the interactive mode (see `Interactive mode`_.):
+on client creation:
 
 .. code-block:: python
 

--- a/doc/source/user_guide/configuration.rst
+++ b/doc/source/user_guide/configuration.rst
@@ -77,8 +77,8 @@ class:
 Interactive mode
 ------------------
 
-When the property `interactive` is set to `true`, the users could enter configuration
-properties from the terminal as they get prompted.
+When the property `interactive` is set to `true`, the users will be prompted for the missing configuration
+properties.
 When the property is `false`, the interactive mode is disabled, and errors would be raised
 in case of missing configuration properties.
 Default behavior is `interactive=true`.

--- a/doc/source/user_guide/configuration.rst
+++ b/doc/source/user_guide/configuration.rst
@@ -83,6 +83,6 @@ When the property is `false`, the interactive mode is disabled, and errors would
 in case of missing configuration properties.
 Default behavior is `interactive=true`.
 
-It is important to note that credentials become required when `interactive=false`.
+It is important to note that login through web browser is disabled and credentials become required when `interactive=false`.
 This means that if the credentials are missing, the users won't be prompted to enter them
 from the terminal, and an error would be raised instead.

--- a/src/ansys/simai/core/client.py
+++ b/src/ansys/simai/core/client.py
@@ -71,12 +71,8 @@ class SimAIClient:
     def __init__(self, **kwargs):
         try:
             config = ClientConfig(**kwargs)
-        except ValidationError as pyandic_exc:
-            missing_properties = [exc["msg"] for exc in pyandic_exc.errors()]
-            raise InvalidConfigurationError(
-                f"""Missing propert{'ies' if len(missing_properties)>1 else 'y'}: """
-                f"""{', '.join(missing_properties)} """
-            ) from None
+        except ValidationError as pydandic_exc:
+            raise InvalidConfigurationError(pydandic_exc) from None
 
         api_client_class = getattr(config, "_api_client_class_override", ApiClient)
         self._api = api_client_class(simai_client=self, config=config)

--- a/src/ansys/simai/core/utils/configuration.py
+++ b/src/ansys/simai/core/utils/configuration.py
@@ -36,6 +36,13 @@ def prompt_for_input_factory(*args, **kwargs):
     return lambda: prompt_for_input(*args, **kwargs)
 
 
+def error_or_prompt(interactive_mode, **kwargs):
+    """Raise an error or prompt for input according to _interactive_mode."""
+    if not interactive_mode:
+        raise ValueError(f"Required field {kwargs['name']} is missing")
+    return prompt_for_input(**kwargs)
+
+
 class Credentials(BaseModel, extra="forbid"):
     username: str = ""  # dummy default, the root validator will call prompt_for_input
     "Username: Required if :code:`Credentials` is defined, automatically prompted."

--- a/src/ansys/simai/core/utils/configuration.py
+++ b/src/ansys/simai/core/utils/configuration.py
@@ -51,9 +51,9 @@ def prompt_if_interactive(interactive, **kwargs):
 
 
 class Credentials(BaseModel, extra="forbid"):
-    username: str  # dummy default, the root validator will call prompt_for_input
+    username: str  # the root validator will call prompt_for_input
     "Username: Required if :code:`Credentials` is defined, automatically prompted."
-    password: str  # dummy default, like above
+    password: str  # like above
     "Password: Required if :code:`Credentials` is defined, automatically prompted."
     totp: Optional[str] = None
     "One-time password: required if :code:`totp_enabled=True`, automatically prompted."

--- a/src/ansys/simai/core/utils/configuration.py
+++ b/src/ansys/simai/core/utils/configuration.py
@@ -45,7 +45,7 @@ def prompt_for_input_factory(*args, **kwargs):
     return lambda: prompt_for_input(*args, **kwargs)
 
 
-def error_or_prompt(interactive_mode, **kwargs):
+def prompt_if_interactive(interactive_mode, **kwargs):
     """Raise an error or prompt for input according to _interactive_mode."""
     if not interactive_mode:
         raise PydanticCustomError(
@@ -66,17 +66,19 @@ class Credentials(BaseModel, extra="forbid"):
     @classmethod
     def prompt(cls, values, info):
         if "username" not in values:
-            values["username"] = prompt_for_input(
+            values["username"] = prompt_if_interactive(
                 interactive_mode=info.data["interactive"], name="username"
             )
         if "password" not in values:
-            values["password"] = error_or_prompt(
+            values["password"] = prompt_if_interactive(
                 interactive_mode=info.data["interactive"],
                 name="password",
                 hide_input=True,
             )
         if values.pop("totp_enabled", False) and "totp" not in values:
-            values["totp"] = error_or_prompt(interactive_mode=info.data["interactive"], name="totp")
+            values["totp"] = prompt_if_interactive(
+                interactive_mode=info.data["interactive"], name="totp"
+            )
         return values
 
 
@@ -137,5 +139,7 @@ class ClientConfig(BaseModel, extra="allow"):
     @classmethod
     def check_organization_exists(cls, val, info):
         if not val:
-            val = error_or_prompt(interactive_mode=info.data["interactive"], name="organization")
+            val = prompt_if_interactive(
+                interactive_mode=info.data["interactive"], name="organization"
+            )
         return val

--- a/src/ansys/simai/core/utils/configuration.py
+++ b/src/ansys/simai/core/utils/configuration.py
@@ -64,6 +64,9 @@ class ClientConfig(BaseModel, extra="allow"):
         default_factory=prompt_for_input_factory("organization"),
         description="Name of the organization(/company) that the user belongs to.",
     )
+    interactive_mode: Optional[bool] = Field(
+        default=True, description="Enable terminal interaction"
+    )
     credentials: Optional[Credentials] = Field(
         default=None,
         description="Authenticate via username/password instead of the device authorization code.",

--- a/src/ansys/simai/core/utils/configuration.py
+++ b/src/ansys/simai/core/utils/configuration.py
@@ -48,14 +48,16 @@ def prompt_for_input_factory(*args, **kwargs):
 def error_or_prompt(interactive_mode, **kwargs):
     """Raise an error or prompt for input according to _interactive_mode."""
     if not interactive_mode:
-        raise PydanticCustomError("param_missing", kwargs["name"])
+        raise PydanticCustomError(
+            "conf_param_missing", f"""Missing parameter "{kwargs["name"]}" from configuration"""
+        )
     return prompt_for_input(**kwargs)
 
 
 class Credentials(BaseModel, extra="forbid"):
-    username: str = ""  # dummy default, the root validator will call prompt_for_input
+    username: str  # dummy default, the root validator will call prompt_for_input
     "Username: Required if :code:`Credentials` is defined, automatically prompted."
-    password: str = ""  # dummy default, like above
+    password: str  # dummy default, like above
     "Password: Required if :code:`Credentials` is defined, automatically prompted."
     totp: Optional[str] = None
     "One-time password: required if :code:`totp_enabled=True`, automatically prompted."
@@ -64,7 +66,7 @@ class Credentials(BaseModel, extra="forbid"):
     @classmethod
     def prompt(cls, values, info):
         if "username" not in values:
-            values["username"] = error_or_prompt(
+            values["username"] = prompt_for_input(
                 interactive_mode=info.data["interactive"], name="username"
             )
         if "password" not in values:
@@ -79,7 +81,9 @@ class Credentials(BaseModel, extra="forbid"):
 
 
 class ClientConfig(BaseModel, extra="allow"):
-    interactive: Optional[bool] = Field(default=True, description="Enable terminal interaction")
+    interactive: Optional[bool] = Field(
+        default=True, description="If True, it enables interaction with the terminal."
+    )
     url: HttpUrl = Field(
         default=HttpUrl("https://api.simai.ansys.com/v2/"),
         description="URL to the SimAI API.",

--- a/src/ansys/simai/core/utils/configuration.py
+++ b/src/ansys/simai/core/utils/configuration.py
@@ -45,9 +45,9 @@ def prompt_for_input_factory(*args, **kwargs):
     return lambda: prompt_for_input(*args, **kwargs)
 
 
-def prompt_if_interactive(interactive_mode, **kwargs):
+def prompt_if_interactive(interactive, **kwargs):
     """Raise an error or prompt for input according to _interactive_mode."""
-    if not interactive_mode:
+    if not interactive:
         raise PydanticCustomError(
             "conf_param_missing", f"""Missing parameter "{kwargs["name"]}" from configuration"""
         )

--- a/src/ansys/simai/core/utils/configuration.py
+++ b/src/ansys/simai/core/utils/configuration.py
@@ -48,7 +48,7 @@ def prompt_for_input_factory(*args, **kwargs):
 def error_or_prompt(interactive_mode, **kwargs):
     """Raise an error or prompt for input according to _interactive_mode."""
     if not interactive_mode:
-        raise PydanticCustomError("missing_param", kwargs["name"])
+        raise PydanticCustomError("param_missing", kwargs["name"])
     return prompt_for_input(**kwargs)
 
 

--- a/src/ansys/simai/core/utils/configuration.py
+++ b/src/ansys/simai/core/utils/configuration.py
@@ -34,6 +34,7 @@ from pydantic import (
     model_validator,
     validator,
 )
+from pydantic_core import PydanticCustomError
 
 from ansys.simai.core.utils.misc import prompt_for_input
 
@@ -47,7 +48,7 @@ def prompt_for_input_factory(*args, **kwargs):
 def error_or_prompt(interactive_mode, **kwargs):
     """Raise an error or prompt for input according to _interactive_mode."""
     if not interactive_mode:
-        raise ValueError(f"Required field {kwargs['name']} is missing")
+        raise PydanticCustomError("missing_param", kwargs["name"])
     return prompt_for_input(**kwargs)
 
 

--- a/src/ansys/simai/core/utils/configuration.py
+++ b/src/ansys/simai/core/utils/configuration.py
@@ -64,9 +64,7 @@ class ClientConfig(BaseModel, extra="allow"):
         default_factory=prompt_for_input_factory("organization"),
         description="Name of the organization(/company) that the user belongs to.",
     )
-    interactive_mode: Optional[bool] = Field(
-        default=True, description="Enable terminal interaction"
-    )
+    interactive: Optional[bool] = Field(default=True, description="Enable terminal interaction")
     credentials: Optional[Credentials] = Field(
         default=None,
         description="Authenticate via username/password instead of the device authorization code.",

--- a/src/ansys/simai/core/utils/configuration.py
+++ b/src/ansys/simai/core/utils/configuration.py
@@ -41,10 +41,6 @@ from ansys.simai.core.utils.misc import prompt_for_input
 logger = logging.getLogger(__name__)
 
 
-def prompt_for_input_factory(*args, **kwargs):
-    return lambda: prompt_for_input(*args, **kwargs)
-
-
 def prompt_if_interactive(interactive, **kwargs):
     """Raise an error or prompt for input according to _interactive_mode."""
     if not interactive:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -104,7 +104,7 @@ from ansys.simai.core.utils.configuration import ClientConfig
         (
             [],
             None,
-            {
+            {  # interactive mode is OFF, and password is missing from credentials
                 "organization": "12_monkeys",
                 "interactive": False,
                 "credentials": {
@@ -116,7 +116,7 @@ from ansys.simai.core.utils.configuration import ClientConfig
         (
             [],
             None,
-            {
+            {  # interactive mode is OFF, and organization is missing
                 "interactive": False,
                 "credentials": {"username": "timmy", "password": "teas"},
             },
@@ -125,7 +125,7 @@ from ansys.simai.core.utils.configuration import ClientConfig
         (
             [],
             None,
-            {
+            {  # interactive mode is OFF, and organization and password are missing
                 "interactive": False,
                 "credentials": {"username": "timmy"},
             },
@@ -134,7 +134,7 @@ from ansys.simai.core.utils.configuration import ClientConfig
         (
             [],
             None,
-            {
+            {  # interactive mode is OFF, and organization and password are missing, and url is not valid
                 "url": "123",
                 "interactive": False,
                 "credentials": {"username": "timmy"},
@@ -144,7 +144,7 @@ from ansys.simai.core.utils.configuration import ClientConfig
         (
             [],
             None,
-            {
+            {  # interactive mode is ON, and credentials are missing
                 "organization": "12_monkeys",
                 "interactive": False,
             },
@@ -160,12 +160,11 @@ def test_get_authentication_configuration(inputs, password, config, expected_out
     mocker.patch("builtins.input", side_effect=inputs)
     mocker.patch("getpass.getpass", return_value=password)
     if expected_output.get("expect_error", None):
-        # if type(expected_output) == type and issubclass(expected_output, Exception):
+        # if an error is expected, catch the exception type and assert the error count
         with pytest.raises(expected_output.get("type")) as ex:
             client_config = ClientConfig(**config)
         assert ex.value.error_count() == expected_output.get("error_count")
     else:
-        # if type(expected_output) is not PydanticCustomError:
         client_config = ClientConfig(**config).dict(exclude_none=True)
         # the config contains many fields, here we only test a subset
         tested_fields = ["organization", "credentials"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -150,6 +150,22 @@ from ansys.simai.core.utils.configuration import ClientConfig
             },
             {"expect_error": True, "type": ValidationError, "error_count": 1},
         ),
+        (
+            [],
+            "pass",
+            {  # sanity check; interactive is set explicitly to ON
+                "interactive": True,
+                "credentials": {"username": "timmy"},
+                "organization": "12_monkeys",
+            },
+            {
+                "credentials": {
+                    "username": "timmy",
+                    "password": "pass",
+                },
+                "organization": "12_monkeys",
+            },
+        ),
     ],
 )
 def test_get_authentication_configuration(inputs, password, config, expected_output, mocker):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,16 +111,44 @@ from ansys.simai.core.utils.configuration import ClientConfig
                     "username": "timmy",
                 },
             },
-            ValidationError,
+            {"expect_error": True, "type": ValidationError, "error_count": 1},
         ),
         (
             [],
             None,
             {
                 "interactive": False,
-                "credentials": {"username": "timmy", "password": "shakaponk"},
+                "credentials": {"username": "timmy", "password": "teas"},
             },
-            ValidationError,
+            {"expect_error": True, "type": ValidationError, "error_count": 1},
+        ),
+        (
+            [],
+            None,
+            {
+                "interactive": False,
+                "credentials": {"username": "timmy"},
+            },
+            {"expect_error": True, "type": ValidationError, "error_count": 2},
+        ),
+        (
+            [],
+            None,
+            {
+                "url": "123",
+                "interactive": False,
+                "credentials": {"username": "timmy"},
+            },
+            {"expect_error": True, "type": ValidationError, "error_count": 3},
+        ),
+        (
+            [],
+            None,
+            {
+                "organization": "12_monkeys",
+                "interactive": False,
+            },
+            {"expect_error": True, "type": ValidationError, "error_count": 1},
         ),
     ],
 )
@@ -131,9 +159,11 @@ def test_get_authentication_configuration(inputs, password, config, expected_out
     """
     mocker.patch("builtins.input", side_effect=inputs)
     mocker.patch("getpass.getpass", return_value=password)
-    if type(expected_output) == type and issubclass(expected_output, Exception):
-        with pytest.raises(expected_output):
+    if expected_output.get("expect_error", None):
+        # if type(expected_output) == type and issubclass(expected_output, Exception):
+        with pytest.raises(expected_output.get("type")) as ex:
             client_config = ClientConfig(**config)
+        assert ex.value.error_count() == expected_output.get("error_count")
     else:
         # if type(expected_output) is not PydanticCustomError:
         client_config = ClientConfig(**config).dict(exclude_none=True)


### PR DESCRIPTION
## Description:
This PR introduces a non-interactive mode where the users do not get prompted for entering the missing configuration properties. To set the interactive mode off, the property `interactive=false` should be introduced to the configuration. Default behavior is `interactive=true` , i.e., interactive mode ON.

Story [sc-6348]

## Implementation
A function, `prompt_if_interactive`, is developed that prompts for input or raises a `PydanticCustomError` according to an input argument. 

### Class `ClientConfig` 
A new parameter `interactice` is introduced in the class to represent the interactive mode. 

A new `field_validator` is developed for validating that the `organization` param is set. It consumes the param `interactice` and parses it to the function `prompt_if_interactive`, where an exception is either raised or not according to the value of `interactice`.

### Class `Credentials`
The Pydantic `model_validator`  of the class consumes the param `interactive` and parses it to `prompt_if_interactive`

### Class `SimAIClient`
The configuration is evaluated in a `try-catch` clause and an `InvalidConfigurationError` is being raised in case of an error in the configuration

## Examples

Script:
```py
import ansys.simai.core as asc

simai = asc.from_config()
```

1. Properties filled correctly (given that the credentials are valid), Interactive mode ON (default behavior)

 Input (conf file)
```toml
[default]
url = "https://api.simai.ansys.com/v2/"
organization = "extrality"

[default.credentials]
username = "basic_user@example.com"
password = "pass"
```
 Output: No-error

2. Properties are missing (organization and password), Interactive mode ON 
 Input (conf file)
```toml
[default]
url = "https://api.simai.ansys.com/v2/"

[default.credentials]
username = "basic_user@example.com"
```
 Output: Prompt user for entering the missing properties
```sh
organization:my_org
password:
```

3. Password property is missing, Interactive mode OFF
Input (conf file)
```toml
[default]
url = "https://api.simai.ansys.com/v2/"
organization = "extrality"
interactive = false

[default.credentials]
username = "basic_user@example.com"
```

Output: return error with missing property
```sh
Traceback (most recent call last):
  File "test_interactive.py", line 3, in <module>
    simai = asc.from_config()
  File "...\sdk\src\ansys\simai\core\client.py", line 297, in from_config
    return cls(**get_config(path, profile, **kwargs))
  File "...\src\ansys\simai\core\client.py", line 76, in __init__
    raise InvalidConfigurationError(pydandic_exc) from None
ansys.simai.core.errors.InvalidConfigurationError: 1 validation error for ClientConfig
credentials
  Missing parameter "password" from configuration [type=conf_param_missing, input_value={'username': 'basic_user@example.com'}, input_type=dict]
```

4. Organization and password properties are missing, Interactive mode OFF

Input (conf file)
```toml
[default]
url = "https://api.simai.ansys.com/v2/"
interactive = false

[default.credentials]
username = "basic_user@example.com"
```

Output: return error with missing properties
```sh
Traceback (most recent call last):
  File "test_interactive.py", line 3, in <module>
    simai = asc.from_config()
  File "...\sdk\src\ansys\simai\core\client.py", line 297, in from_config
    return cls(**get_config(path, profile, **kwargs))
  File "...\src\ansys\simai\core\client.py", line 76, in __init__
    raise InvalidConfigurationError(pydandic_exc) from None
ansys.simai.core.errors.InvalidConfigurationError: 2 validation errors for ClientConfig
organization
  Missing parameter "organization" from configuration [type=conf_param_missing, input_value=None, input_type=NoneType]
credentials
  Missing parameter "password" from configuration [type=conf_param_missing, input_value={'username': 'basic_user@example.com'}, input_type=dict]
```

5. Organization and password properties are missing, `url` property is a not valid url, and Interactive mode OFF
Input (conf file)
```toml
[default]
url = "123"
interactive = false

[default.credentials]
username = "basic_user@example.com"
```

Output: return errors with missing properties and not valid url
```sh
Traceback (most recent call last):
  File "test_interactive.py", line 3, in <module>
    simai = asc.from_config()
  File "...\sdk\src\ansys\simai\core\client.py", line 297, in from_config
    return cls(**get_config(path, profile, **kwargs))
  File "...\src\ansys\simai\core\client.py", line 76, in __init__
    raise InvalidConfigurationError(pydandic_exc) from None
ansys.simai.core.errors.InvalidConfigurationError: 3 validation errors for ClientConfig
url
  Input should be a valid URL, relative URL without a base [type=url_parsing, input_value='123/', input_type=str]
    For further information visit https://errors.pydantic.dev/2.5/v/url_parsing
organization
  Missing parameter "organization" from configuration [type=conf_param_missing, input_value=None, input_type=NoneType]
credentials
  Missing parameter "password" from configuration [type=conf_param_missing, input_value={'username': 'basic_user@example.com'}, input_type=dict]
```

6. Credentials section is required in non-interactive mode
Input (conf file)
```toml
[default]
url = "https://api.simai.ansys.com/v2/"
interactive = false
```

Output
```sh
Traceback (most recent call last):
  File "test_interactive.py", line 3, in <module>
    simai = asc.from_config()
  File "...\sdk\src\ansys\simai\core\client.py", line 297, in from_config
    return cls(**get_config(path, profile, **kwargs))
  File "...\src\ansys\simai\core\client.py", line 76, in __init__
    raise InvalidConfigurationError(pydandic_exc) from None
ansys.simai.core.errors.InvalidConfigurationError: 1 validation error for ClientConfig
credentials
  Credentials should exist when interactive is false [type=creds_missing_in_non_interactive, input_value=None, input_type=NoneType]
```
