### PR TITLE
Use last build configuration for a new build

### DIFF
--- a/doc/source/api_reference/models.rst
+++ b/doc/source/api_reference/models.rst
@@ -1,0 +1,30 @@
+.. _models:
+
+Build Model
+==============
+
+.. py:module:: ansys.simai.core.data.models
+
+A ModelConf contains the required information for launching a build.
+
+
+ModelConfiguration
+------------------
+
+.. autoclass:: ModelConfiguration()
+    :members:
+
+
+Directory
+---------
+
+.. autoclass:: ModelDirectory()
+    :members:
+    :exclude-members: get
+
+
+Model
+---------
+
+.. autoclass:: Model()
+    :members:

--- a/doc/source/api_reference/models.rst
+++ b/doc/source/api_reference/models.rst
@@ -8,7 +8,7 @@ Build a Model
 A collection for classes for building a SimAI model.
 Launching a build requires a configuration
 (:py:class:`ModelConfiguration<ansys.simai.core.data.models.ModelConfiguration>`)
-with defines the model  properties, such as its inputs and outputs,
+which defines the model properties, such as its inputs and outputs,
 the Global Coefficients and the Domain of Analysis, and its project id. The
 :py:class:`ModelConfiguration<ansys.simai.core.data.models.ModelConfiguration>`
 object is, then, parsed to :py:meth:`models.build()<ModelDirectory.build>` for

--- a/doc/source/api_reference/models.rst
+++ b/doc/source/api_reference/models.rst
@@ -5,7 +5,14 @@ Build Model
 
 .. py:module:: ansys.simai.core.data.models
 
-A ModelConf contains the required information for launching a build.
+A collection for classes for launching a build of a SimAI model.
+Launing a build requires a configuration
+(:py:class:`ModelConfiguration<ansys.simai.core.data.models.ModelConfiguration>`)
+with defines the model  properties, such as its inputs and outputs,
+the Global Coefficients and the Domain of Analysis, and its project id. The
+:py:class:`ModelConfiguration<ansys.simai.core.data.models.ModelConfiguration>`
+object is, then, parsed to :py:meth:`models.build()<ModelDirectory.build>` for
+launching a build.
 
 
 ModelConfiguration

--- a/doc/source/api_reference/models.rst
+++ b/doc/source/api_reference/models.rst
@@ -1,12 +1,12 @@
 .. _models:
 
-Build Model
+Build a Model
 ==============
 
 .. py:module:: ansys.simai.core.data.models
 
-A collection for classes for launching a build of a SimAI model.
-Launing a build requires a configuration
+A collection for classes for building a SimAI model.
+Launching a build requires a configuration
 (:py:class:`ModelConfiguration<ansys.simai.core.data.models.ModelConfiguration>`)
 with defines the model  properties, such as its inputs and outputs,
 the Global Coefficients and the Domain of Analysis, and its project id. The

--- a/src/ansys/simai/core/api/project.py
+++ b/src/ansys/simai/core/api/project.py
@@ -70,15 +70,21 @@ class ProjectClientMixin(ApiClientMixin):
     def launch_build(
         self,
         project_id: str,
-        build_config: Dict[str, Any],
-        dismiss_data_with_fields_discrepancie: bool = False,
+        config: Dict[str, Any],
+        dismiss_data_with_fields_discrepancies: bool = False,
         dismiss_data_with_volume_overflow: bool = False,
     ):
+        """Launches a build for a project and according to a given configuration.
+
+        Args:
+            project_id: the ID of the project
+            config: the build configuration
+            dismiss_data_with_fields_discrepancies: set to True for omitting training data with missing properties
+            dismiss_data_with_volume_overflow: set to True to
+
+        """
         params = {
-            "dismiss_data_with_fields_discrepancies": dismiss_data_with_fields_discrepancie,
+            "dismiss_data_with_fields_discrepancies": dismiss_data_with_fields_discrepancies,
             "dismiss_data_with_volume_overflow": dismiss_data_with_volume_overflow,
         }
-        return self._post(f"projects/{project_id}/model", json=build_config, params=params)
-
-    def get_model(self, project_id: str):
-        return self._get(f"projects/{project_id}/model")
+        return self._post(f"projects/{project_id}/model", json=config, params=params)

--- a/src/ansys/simai/core/api/project.py
+++ b/src/ansys/simai/core/api/project.py
@@ -79,8 +79,8 @@ class ProjectClientMixin(ApiClientMixin):
         Args:
             project_id: the ID of the project
             config: the build configuration
-            dismiss_data_with_fields_discrepancies: set to True for omitting training data with missing properties
-            dismiss_data_with_volume_overflow: set to True to
+            dismiss_data_with_fields_discrepancies: set to True for omitting data with missing properties
+            dismiss_data_with_volume_overflow: set to True for omitting data outside the Domain of Analysis
 
         """
         params = {

--- a/src/ansys/simai/core/api/project.py
+++ b/src/ansys/simai/core/api/project.py
@@ -66,3 +66,19 @@ class ProjectClientMixin(ApiClientMixin):
 
     def delete_project(self, project_id: str):
         self._delete(f"projects/{project_id}", return_json=False)
+
+    def launch_build(
+        self,
+        project_id: str,
+        build_config: Dict[str, Any],
+        dismiss_data_with_fields_discrepancie: bool = False,
+        dismiss_data_with_volume_overflow: bool = False,
+    ):
+        params = {
+            "dismiss_data_with_fields_discrepancies": dismiss_data_with_fields_discrepancie,
+            "dismiss_data_with_volume_overflow": dismiss_data_with_volume_overflow,
+        }
+        return self._post(f"projects/{project_id}/model", json=build_config, params=params)
+
+    def get_model(self, project_id: str):
+        return self._get(f"projects/{project_id}/model")

--- a/src/ansys/simai/core/client.py
+++ b/src/ansys/simai/core/client.py
@@ -30,7 +30,11 @@ from ansys.simai.core import __version__
 from ansys.simai.core.api.client import ApiClient
 from ansys.simai.core.data.design_of_experiments import DesignOfExperimentsCollection
 from ansys.simai.core.data.geometries import GeometryDirectory
-from ansys.simai.core.data.optimizations import OptimizationDirectory, OptimizationTrialRunDirectory
+from ansys.simai.core.data.models import ModelDirectory
+from ansys.simai.core.data.optimizations import (
+    OptimizationDirectory,
+    OptimizationTrialRunDirectory,
+)
 from ansys.simai.core.data.post_processings import PostProcessingDirectory
 from ansys.simai.core.data.predictions import PredictionDirectory
 from ansys.simai.core.data.projects import Project, ProjectDirectory
@@ -82,6 +86,7 @@ class SimAIClient:
         self._optimization_trial_run_directory = OptimizationTrialRunDirectory(client=self)
         self._post_processing_directory = PostProcessingDirectory(client=self)
         self._project_directory = ProjectDirectory(client=self)
+        self._model_directory = ModelDirectory(client=self)
         self._workspace_directory = WorkspaceDirectory(client=self)
         self._prediction_directory = PredictionDirectory(client=self)
         self._training_data_directory = TrainingDataDirectory(client=self)
@@ -247,6 +252,13 @@ class SimAIClient:
         For more information, see :ref:`workspaces`.
         """
         return self._workspace_directory
+
+    @property
+    def models(self):
+        """Representation of all workspaces on the server.
+        For more information, see :ref:`workspaces`.
+        """
+        return self._model_directory
 
     @classmethod
     def from_config(

--- a/src/ansys/simai/core/data/models.py
+++ b/src/ansys/simai/core/data/models.py
@@ -28,7 +28,7 @@ from ansys.simai.core.data.base import ComputableDataModel, Directory
 
 @dataclass
 class ModelConfiguration:
-    """Build configuration."""
+    """The configuration for building a model."""
 
     boundary_conditions: Dict[str, Any] = None
     build_preset: str = None
@@ -52,7 +52,7 @@ class Model(ComputableDataModel):
 
 
 class ModelDirectory(Directory[Model]):
-    """Provides a collection of methods related to training models."""
+    """Provides a collection of methods related to building models."""
 
     _data_model = Model
 
@@ -80,6 +80,7 @@ class ModelDirectory(Directory[Model]):
 
         Example:
             Use a previous configuration for a new build
+
             .. code-block:: python
 
                 a_project = simai.projects.get("project_A")

--- a/src/ansys/simai/core/data/models.py
+++ b/src/ansys/simai/core/data/models.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List
+
+from ansys.simai.core.data.base import ComputableDataModel, Directory
+
+
+@dataclass
+class BuildConfiguration:
+    """Build configuration."""
+
+    boundary_conditions: Dict[str, Any] = None
+    build_preset: str = None
+    continuous: bool = False
+    fields: Dict[str, Any] = None
+    global_coefficients: List[Dict[str, Any]] = None
+    simulation_volume: Dict[str, Any] = None
+    project_id: str = None
+
+
+class Model(ComputableDataModel):
+    """Training model representation."""
+
+    def __repr__(self) -> str:
+        return f"<Model: {self.id}>"
+
+    @property
+    def configuration(self):
+        """The build configuration of model."""
+        return BuildConfiguration(**self.fields["configuration"])
+
+
+class ModelDirectory(Directory[Model]):
+    """Provides a collection of methods related to training models."""
+
+    _data_model = Model
+
+    def get(self, project_id: str) -> Model:
+        """Get a model by project ID.
+
+        Args:
+            project_id: ID of the project.
+        """
+
+        return self._model_from(self._client._api.get_model(project_id))
+
+    def build(
+        self,
+        configuration: BuildConfiguration,
+        dismiss_data_with_fields_discrepancies: bool = False,
+        dismiss_data_with_volume_overflow: bool = False,
+    ):
+        """Launches a build given a configuration."""
+        build_conf = asdict(configuration)
+        project_id = build_conf.pop("project_id")
+        return self._model_from(
+            self._client._api.launch_build(
+                project_id,
+                build_conf,
+                dismiss_data_with_fields_discrepancies,
+                dismiss_data_with_volume_overflow,
+            )
+        )

--- a/src/ansys/simai/core/data/models.py
+++ b/src/ansys/simai/core/data/models.py
@@ -27,7 +27,7 @@ from ansys.simai.core.data.base import ComputableDataModel, Directory
 
 
 @dataclass
-class BuildConfiguration:
+class ModelConfiguration:
     """Build configuration."""
 
     boundary_conditions: Dict[str, Any] = None
@@ -46,9 +46,9 @@ class Model(ComputableDataModel):
         return f"<Model: {self.id}>"
 
     @property
-    def configuration(self):
+    def configuration(self) -> ModelConfiguration:
         """The build configuration of model."""
-        return BuildConfiguration(**self.fields["configuration"])
+        return ModelConfiguration(**self.fields["configuration"])
 
 
 class ModelDirectory(Directory[Model]):
@@ -56,22 +56,39 @@ class ModelDirectory(Directory[Model]):
 
     _data_model = Model
 
-    def get(self, project_id: str) -> Model:
-        """Get a model by project ID.
+    def get(self, model_id: str) -> Model:
+        """[Do not use] Get a model by project ID.
 
         Args:
-            project_id: ID of the project.
+            model_id: ID of the project.
         """
 
-        return self._model_from(self._client._api.get_model(project_id))
+        raise NotImplementedError("The method 'get' of the class Model is not implemented yet.")
 
     def build(
         self,
-        configuration: BuildConfiguration,
+        configuration: ModelConfiguration,
         dismiss_data_with_fields_discrepancies: bool = False,
         dismiss_data_with_volume_overflow: bool = False,
     ):
-        """Launches a build given a configuration."""
+        """Launches a build given a configuration.
+
+        Args:
+            configuration: a ModelConfiguration object that contains the properties to be used in the build
+            dismiss_data_with_fields_discrepancies: set to True for omitting training data with missing properties
+            dismiss_data_with_volume_overflow: set to True to
+
+        Example:
+            Use a previous configuration for a new build
+            .. code-block:: python
+
+                a_project = simai.projects.get("project_A")
+
+                build_conf = a_project.last_model_configuration
+
+                new_model = simai.models.build(build_conf)
+
+        """
         build_conf = asdict(configuration)
         project_id = build_conf.pop("project_id")
         return self._model_from(

--- a/src/ansys/simai/core/data/models.py
+++ b/src/ansys/simai/core/data/models.py
@@ -46,9 +46,14 @@ class Model(ComputableDataModel):
         return f"<Model: {self.id}>"
 
     @property
+    def project_id(self) -> str:
+        """The ID of the model's project."""
+        return self.fields["project_id"]
+
+    @property
     def configuration(self) -> ModelConfiguration:
         """The build configuration of model."""
-        return ModelConfiguration(**self.fields["configuration"])
+        return ModelConfiguration(project_id=self.project_id, **self.fields["configuration"])
 
 
 class ModelDirectory(Directory[Model]):
@@ -75,8 +80,8 @@ class ModelDirectory(Directory[Model]):
 
         Args:
             configuration: a ModelConfiguration object that contains the properties to be used in the build
-            dismiss_data_with_fields_discrepancies: set to True for omitting training data with missing properties
-            dismiss_data_with_volume_overflow: set to True to
+            dismiss_data_with_fields_discrepancies: set to True for omitting data with missing properties
+            dismiss_data_with_volume_overflow: set to True for omitting data outside the Domain of Analysis
 
         Example:
             Use a previous configuration for a new build

--- a/src/ansys/simai/core/data/models.py
+++ b/src/ansys/simai/core/data/models.py
@@ -65,7 +65,7 @@ class ModelDirectory(Directory[Model]):
         """[Do not use] Get a model by project ID.
 
         Args:
-            model_id: ID of the project.
+            model_id: ID of the model.
         """
 
         raise NotImplementedError("The method 'get' of the class Model is not implemented yet.")

--- a/src/ansys/simai/core/data/models.py
+++ b/src/ansys/simai/core/data/models.py
@@ -47,7 +47,7 @@ class Model(ComputableDataModel):
 
     @property
     def project_id(self) -> str:
-        """The ID of the model's project."""
+        """The ID of the project where the model exists."""
         return self.fields["project_id"]
 
     @property
@@ -84,13 +84,28 @@ class ModelDirectory(Directory[Model]):
             dismiss_data_with_volume_overflow: set to True for omitting data outside the Domain of Analysis
 
         Example:
-            Use a previous configuration for a new build
+            Use a previous configuration for a new build in the same project
 
             .. code-block:: python
 
                 a_project = simai.projects.get("project_A")
 
                 build_conf = a_project.last_model_configuration
+
+                new_model = simai.models.build(build_conf)
+
+            Use a previous configuration for a new build in another project
+
+            .. code-block:: python
+
+                a_project = simai.projects.get("project_A")
+
+                build_conf = a_project.last_model_configuration
+
+                b_project = simai.projects.get("project_B")
+
+                # set the id of b_project as the project_id of the configuration
+                builf_conf.project_id = b_project.id
 
                 new_model = simai.models.build(build_conf)
 

--- a/src/ansys/simai/core/data/projects.py
+++ b/src/ansys/simai/core/data/projects.py
@@ -76,7 +76,7 @@ class Project(DataModel):
 
     @property
     def last_model_configuration(self) -> ModelConfiguration:
-        """The last configuration :class:`~ansys.simai.core.data.models.ModelConfiguration` that was used for training a model in this project."""
+        """The last :class:`configuration <ansys.simai.core.data.models.ModelConfiguration>` that was used for training a model in this project."""
         return ModelConfiguration(project_id=self.id, **self.fields.get("last_model_configuration"))
 
     def delete(self) -> None:

--- a/src/ansys/simai/core/data/projects.py
+++ b/src/ansys/simai/core/data/projects.py
@@ -76,7 +76,7 @@ class Project(DataModel):
 
     @property
     def last_model_configuration(self) -> ModelConfiguration:
-        """The last configuration that was used for training a model in this project."""
+        """The last configuration :class:`~ansys.simai.core.data.models.ModelConfiguration` that was used for training a model in this project."""
         return ModelConfiguration(project_id=self.id, **self.fields.get("last_model_configuration"))
 
     def delete(self) -> None:

--- a/src/ansys/simai/core/data/projects.py
+++ b/src/ansys/simai/core/data/projects.py
@@ -23,7 +23,7 @@
 from typing import TYPE_CHECKING, List, Optional
 
 from ansys.simai.core.data.base import DataModel, Directory
-from ansys.simai.core.data.models import BuildConfiguration
+from ansys.simai.core.data.models import ModelConfiguration
 from ansys.simai.core.data.types import Identifiable, get_id_from_identifiable
 from ansys.simai.core.errors import InvalidArguments
 
@@ -75,9 +75,9 @@ class Project(DataModel):
         self.reload()
 
     @property
-    def last_model_configuration(self):
+    def last_model_configuration(self) -> ModelConfiguration:
         """The last configuration that was used for training a model in this project."""
-        return BuildConfiguration(project_id=self.id, **self.fields.get("last_model_configuration"))
+        return ModelConfiguration(project_id=self.id, **self.fields.get("last_model_configuration"))
 
     def delete(self) -> None:
         """Delete the project."""

--- a/src/ansys/simai/core/data/projects.py
+++ b/src/ansys/simai/core/data/projects.py
@@ -23,6 +23,7 @@
 from typing import TYPE_CHECKING, List, Optional
 
 from ansys.simai.core.data.base import DataModel, Directory
+from ansys.simai.core.data.models import BuildConfiguration
 from ansys.simai.core.data.types import Identifiable, get_id_from_identifiable
 from ansys.simai.core.errors import InvalidArguments
 
@@ -76,7 +77,7 @@ class Project(DataModel):
     @property
     def last_model_configuration(self):
         """The last configuration that was used for training a model in this project."""
-        return self.fields.get("last_model_configuration")
+        return BuildConfiguration(project_id=self.id, **self.fields.get("last_model_configuration"))
 
     def delete(self) -> None:
         """Delete the project."""

--- a/src/ansys/simai/core/data/projects.py
+++ b/src/ansys/simai/core/data/projects.py
@@ -73,6 +73,11 @@ class Project(DataModel):
         self._client._api.set_project_sample(self.id, td_id)
         self.reload()
 
+    @property
+    def last_model_configuration(self):
+        """The last configuration that was used for training a model in this project."""
+        return self.fields.get("last_model_configuration")
+
     def delete(self) -> None:
         """Delete the project."""
         self._client._api.delete_project(self.id)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -113,7 +113,7 @@ MODEL_RAW = {
 
 
 @responses.activate
-def test_launch_build(simai_client):
+def test_build(simai_client):
     """WHEN I call launch_build() with a ModelConfiguration
     THEN I get a Model object, its project_id matches the
     id of the project, and its configuration is a

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+import responses
+
+from ansys.simai.core.data.models import ModelConfiguration
+
+if TYPE_CHECKING:
+    from ansys.simai.core.data.models import Model
+
+
+MODEL_CONF_RAW = {
+    "boundary_conditions": {"Vx": {}},
+    "build_preset": "debug",
+    "continuous": False,
+    "fields": {
+        "surface": [
+            {
+                "format": "value",
+                "keys": None,
+                "location": "cell",
+                "name": "Pressure",
+                "unit": None,
+            },
+            {
+                "format": "value",
+                "keys": None,
+                "location": "cell",
+                "name": "WallShearStress_0",
+                "unit": None,
+            },
+        ],
+        "surface_input": [],
+        "volume": [
+            {
+                "format": "value",
+                "keys": None,
+                "location": "cell",
+                "name": "Pressure",
+                "unit": None,
+            },
+            {
+                "format": "value",
+                "keys": None,
+                "location": "cell",
+                "name": "Velocity_0",
+                "unit": None,
+            },
+            {
+                "format": "value",
+                "keys": None,
+                "location": "cell",
+                "name": "Velocity_1",
+                "unit": None,
+            },
+            {
+                "format": "value",
+                "keys": None,
+                "location": "cell",
+                "name": "VolumeFractionWater",
+                "unit": None,
+            },
+        ],
+    },
+    "global_coefficients": [{"formula": "max(Pressure)", "name": "maxpress"}],
+    "simulation_volume": {
+        "X": {"length": 300.0, "type": "relative_to_min", "value": 15.0},
+        "Y": {"length": 80.0, "type": "absolute", "value": -80},
+        "Z": {"length": 40.0, "type": "absolute", "value": -20.0},
+    },
+}
+
+MODEL_RAW = {
+    "configuration": MODEL_CONF_RAW,
+    "coreml_version": "5.666.333",
+    "creation_time": "2035-07-08T16:26:51.943312",
+    "error": None,
+    "has_custom_training_configuration": False,
+    "hidden": False,
+    "id": "2yg3vpq9",
+    "is_deployed": False,
+    "manifest": {},
+    "name": "pspsps",
+    "project_id": "r291h3yk",
+    "state": "pending request",
+    "training_configuration": None,
+    "updated_time": "2036-12-08T16:26:51.953502",
+    "version": None,
+    "workspaces": [],
+}
+
+
+@responses.activate
+def test_launch_build(simai_client):
+    """WHEN I call launch_build() with a ModelConfiguration
+    THEN I get a Model object, its project_id matches the
+    id of the project, and its configuration is a
+    ModelConfiguration and its content matches the raw conf.
+    """
+
+    responses.add(
+        responses.POST,
+        f"https://test.test/projects/{MODEL_RAW['project_id']}/model",
+        json=MODEL_RAW,
+        status=200,
+    )
+
+    in_model_conf = ModelConfiguration(project_id=MODEL_RAW["project_id"], **MODEL_CONF_RAW)
+
+    launched_model: Model = simai_client.models.build(in_model_conf)
+
+    assert isinstance(launched_model.configuration, ModelConfiguration)
+    assert launched_model.project_id == MODEL_RAW["project_id"]
+
+    model_conf = asdict(launched_model.configuration)
+    model_conf.pop("project_id")
+
+    assert model_conf == MODEL_CONF_RAW

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -138,6 +138,7 @@ def test_last_model_configuration(simai_client):
     assert asdict(project_last_conf) == (last_conf | {"project_id": raw_project.get("id")})
 
 
+@responses.activate
 @pytest.mark.parametrize(
     "status_code,response_body,error_type",
     [

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -20,10 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from dataclasses import asdict
 from typing import TYPE_CHECKING
 
 import responses
 
+from ansys.simai.core.data.models import ModelConfiguration
 from ansys.simai.core.data.training_data import TrainingData
 
 if TYPE_CHECKING:
@@ -97,3 +99,38 @@ def test_project_sample(simai_client):
     project.sample = raw_td["id"]
     assert isinstance(project.sample, TrainingData)
     assert project.sample.id == raw_td["id"]
+
+
+@responses.activate
+def test_last_model_configuration(simai_client):
+    """Test last_configuration property."""
+
+    last_conf = {
+        "boundary_conditions": {"Vx": {}},
+        "build_preset": "debug",
+        "continuous": False,
+        "fields": {},
+        "global_coefficients": None,
+        "simulation_volume": None,
+    }
+
+    raw_project = {
+        "id": "xX007Xx",
+        "name": "fifi",
+        "sample": None,
+        "last_model_configuration": last_conf,
+    }
+
+    project: Project = simai_client._project_directory._model_from(raw_project)
+
+    responses.add(
+        responses.GET,
+        f"https://test.test/projects/{project.id}/",
+        status=200,
+        json=raw_project,
+    )
+
+    project_last_conf = project.last_model_configuration
+
+    assert isinstance(project_last_conf, ModelConfiguration)
+    assert asdict(project_last_conf) == (last_conf | {"project_id": raw_project.get("id")})


### PR DESCRIPTION
## Description 

It enable launching a build using an already existing configuration from a project

Usage: 

```py
my_project = simai.projects.get("my_project")

build_conf = my_project.last_model_configuration

launched_model = simai.models.build(build_conf)

model_id = launched_model .id

model_config = launched_model .configuration
```

If the user wants to use the configuration to another project, then:

```py
my_project = simai.projects.get("my_project")

build_conf = my_project.last_model_configuration

# assuming that the other_project is trainable
other_project = simai.projects.get("other_project")

builf_conf.project_id = other_project .id

launched_model = simai.models.build(build_conf)
```

## Remarks

- Since the models are hidden (the GET request to `/<project_id>/models` returns authorization error), the method `get` of the class `ModelDirectory` raises a `NotImplementedError` error when used. Not 100% sure if this the best practice 😟 Maybe, just passing would be ok, since it is not supported yet. 

## Tests

- Tested against Dev
- Unit tests
