### PR TITLE
doc: Add inherited-members to PostProcessing doc

### DIFF
--- a/doc/source/api_reference/post_processings.rst
+++ b/doc/source/api_reference/post_processings.rst
@@ -16,6 +16,7 @@ Model
 
 .. autoclass:: PostProcessing()
     :members:
+    :inherited-members:
 
 
 .. _pp_methods:


### PR DESCRIPTION
So that properties like `is_ready` are documented.