### PR TITLE
Handle SEE event on model training

### DIFF
--- a/src/ansys/simai/core/api/sse.py
+++ b/src/ansys/simai/core/api/sse.py
@@ -132,6 +132,8 @@ class SSEMixin(ApiClientMixin):
             self.simai_client.optimizations._handle_sse_event(data)
         elif target["type"] == "optimization_trial_run":
             self.simai_client._optimization_trial_run_directory._handle_sse_event(data)
+        elif target["type"] == "model":
+            self.simai_client._model_directory._handle_sse_event(data)
         elif target["type"] == "project":
             if "action" in target:
                 if target["action"] == "check":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ import pytest
 from ansys.simai.core import SimAIClient
 from ansys.simai.core.api.client import ApiClient
 from ansys.simai.core.data.geometries import Geometry, GeometryDirectory
+from ansys.simai.core.data.models import Model
 from ansys.simai.core.data.post_processings import (
     PostProcessing,
     PostProcessingDirectory,
@@ -215,5 +216,19 @@ def global_coefficient_request_factory(simai_client):
             return simai_client._check_gc_formula_directory._model_from(**kwargs)
         elif request_type == "compute":
             return simai_client._compute_gc_formula_directory._model_from(**kwargs)
+
+    return _factory
+
+
+@pytest.fixture()
+def model_factory(simai_client) -> Model:
+    """Returns a function to create a :py:class:`Model`."""
+
+    def _factory(**kwargs) -> Model:
+        kwargs.setdefault("id", str(random.random()))
+        kwargs.setdefault("name", kwargs["id"])
+
+        model = simai_client._model_directory._model_from(kwargs)
+        return model
 
     return _factory

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -448,3 +448,30 @@ def test_exception_setting_global_coefficient():
 
     with pytest.raises(ProcessingError):
         ModelConfiguration(project=None, **MODEL_CONF_RAW)
+
+
+def test_sse_event_handler(simai_client, model_factory):
+    """WHEN SSE signals successful state,
+    THEN model becomes ready.
+    """
+    model = model_factory(state="processing")
+    updated_record = model.fields.copy()
+    updated_record.update({"state": "successful"})
+    simai_client._model_directory._handle_sse_event(
+        {
+            "type": "job",
+            "status": "successful",
+            "target": {"id": model.id, "project": "o14qpmvy", "type": "model"},
+            "record": {
+                "id": model.id,
+                "state": "successful",
+                "project_id": "o14qpmvy",
+                "workspaces": [],
+                "name": "test",
+                "version": None,
+                "manifest": {},
+                "configuration": {},
+            },
+        }
+    )
+    assert model.is_ready


### PR DESCRIPTION
## Description

This PR adds a `model` case to the SSE handler so that SSEs for training can be consumed after build requests and the `wait` method of `Model` is not let hanging. 

story: [sc-22783]