### PR TITLE
fix method compute_global_coefficient

### DIFF
--- a/src/ansys/simai/core/data/model_configuration.py
+++ b/src/ansys/simai/core/data/model_configuration.py
@@ -435,5 +435,5 @@ class ModelConfiguration:
             self.project.compute_gc_formula(
                 gc.formula, self.input.boundary_conditions, self.output.surface
             )
-            for gc in self.output.global_coefficients
+            for gc in self.global_coefficients
         ]


### PR DESCRIPTION
## Description

The method `compute_global_coefficient` was breaking because it mistakenly pulling the GC formulas from the `output` instead from its member.

This PR fixes it by setting the GC formulas to retrieved from the member `global_coefficients`

Story: sc-23053