### PR TITLE
Doc: Improvements in training_data.py

### DIFF
--- a/src/ansys/simai/core/data/training_data.py
+++ b/src/ansys/simai/core/data/training_data.py
@@ -87,8 +87,9 @@ class TrainingData(ComputableDataModel):
                 the :class:`~.projects.Project` object for, or its ID.
 
         Returns:
-            The :obj:`~ansys.simai.core.data.types.SubsetEnum` of the subset to which the :class:`TrainingData` belongs to if any, ``None`` otherwise.
-                (e.g. <SubsetEnum.TEST: 'Test'>)
+            The :obj:`~ansys.simai.core.data.types.SubsetEnum` of the subset to which 
+            the :class:`TrainingData` belongs to if any, ``None`` otherwise.
+            (e.g. <SubsetEnum.TEST: 'Test'>)
         """
         project_id = get_id_from_identifiable(project, default=self._client._current_project)
         subset_value = self._client._api.get_training_data_subset(project_id, self.id).get("subset")
@@ -97,12 +98,19 @@ class TrainingData(ComputableDataModel):
     def assign_subset(
         self, project: Identifiable["Project"], subset: Optional[Union[SubsetEnum, str]]
     ) -> None:
-        """Assign the training data subset in relation to a given project.
+        """Assign the training data to a subset in relation to a given project.
 
         Args:
             project: ID or :class:`model <.projects.Project>`
             subset: SubsetEnum attribute (e.g. SubsetEnum.TRAINING) or string value (e.g. "Training") or None to unassign.
                 Available options: (Training, Test)
+
+                Each subset requires at least one data point.
+                The training subset is used to train the model. The test subset is used for the model
+                evaluation report but is not learned by the model.
+                It is recommended to allocate about 10% of your data to the test subset.
+
+                None allows you to reset the assignment of your training data
 
         Returns:
             None

--- a/src/ansys/simai/core/data/training_data.py
+++ b/src/ansys/simai/core/data/training_data.py
@@ -105,12 +105,20 @@ class TrainingData(ComputableDataModel):
             subset: SubsetEnum attribute (e.g. SubsetEnum.TRAINING) or string value (e.g. "Training") or None to unassign.
                 Available options: (Training, Test)
 
+                Each new training data added to the project will be set to "None" by default.
+                
+                None allows for resetting the subset assignment of your training data, which will be automatically allocated 
+                in either Test or Training sets upon each model building request. As a rule of thumb, 10% of all data should
+                be allocated to the Test set.
+
+                When wanting to assign a specific subset to your training data, note that:
+                
                 Each subset requires at least one data point.
                 The training subset is used to train the model. The test subset is used for the model
                 evaluation report but is not learned by the model.
                 It is recommended to allocate about 10% of your data to the test subset.
 
-                None allows you to reset the assignment of your training data
+                
 
         Returns:
             None

--- a/src/ansys/simai/core/data/training_data.py
+++ b/src/ansys/simai/core/data/training_data.py
@@ -87,7 +87,7 @@ class TrainingData(ComputableDataModel):
                 the :class:`~.projects.Project` object for, or its ID.
 
         Returns:
-            The :obj:`~ansys.simai.core.data.types.SubsetEnum` of the subset to which 
+            The :obj:`~ansys.simai.core.data.types.SubsetEnum` of the subset to which
             the :class:`TrainingData` belongs to if any, ``None`` otherwise.
             (e.g. <SubsetEnum.TEST: 'Test'>)
         """
@@ -106,19 +106,17 @@ class TrainingData(ComputableDataModel):
                 Available options: (Training, Test)
 
                 Each new training data added to the project will be set to "None" by default.
-                
-                None allows for resetting the subset assignment of your training data, which will be automatically allocated 
-                in either Test or Training sets upon each model building request. As a rule of thumb, 10% of all data should
-                be allocated to the Test set.
+
+                None allows for resetting the subset assignment of your training data, which will be automatically allocated
+                in either test or training subsets upon each model building request. As a rule of thumb, 10% of all data should
+                be allocated to the test subset.
 
                 When wanting to assign a specific subset to your training data, note that:
-                
+
                 Each subset requires at least one data point.
                 The training subset is used to train the model. The test subset is used for the model
                 evaluation report but is not learned by the model.
                 It is recommended to allocate about 10% of your data to the test subset.
-
-                
 
         Returns:
             None


### PR DESCRIPTION
[Shortcut ticket](https://app.shortcut.com/simai/story/23032/sdk-edits-for-tain-test-val-disclaimer)
This PR contains two edits made in the training_data.py file:

- One edit to correct a rendering issue in the current documentation.
- The addition of a paragraph to improve the definition of the assign_subset method's arguments.