### PR TITLE
[Fix] Exception when volume is missing from sample

### DIFF
--- a/src/ansys/simai/core/data/model_configuration.py
+++ b/src/ansys/simai/core/data/model_configuration.py
@@ -391,6 +391,10 @@ class ModelConfiguration:
 
         volume_fld = []
         if self.output.volume is not None:
+            if self.output.volume and not sample_metadata.get("volume"):
+                raise ProcessingError(
+                    "The reference sample should have a volume file in order to use volume variables."
+                ) from None
             volume_fld = [
                 fd
                 for fd in sample_metadata.get("volume").get("fields")

--- a/src/ansys/simai/core/data/model_configuration.py
+++ b/src/ansys/simai/core/data/model_configuration.py
@@ -393,7 +393,7 @@ class ModelConfiguration:
         if self.output.volume is not None:
             if self.output.volume and not sample_metadata.get("volume"):
                 raise ProcessingError(
-                    "The reference sample should have a volume file in order to use volume variables."
+                    "No volume file was found in the reference sample. A volume file is required to use volume variables."
                 ) from None
             volume_fld = [
                 fd

--- a/src/ansys/simai/core/data/model_configuration.py
+++ b/src/ansys/simai/core/data/model_configuration.py
@@ -390,14 +390,14 @@ class ModelConfiguration:
             ]
 
         volume_fld = []
-        if self.output.volume is not None:
-            if self.output.volume and not sample_metadata.get("volume"):
+        if self.output.volume:
+            if not sample_metadata.get("volume"):
                 raise ProcessingError(
                     "No volume file was found in the reference sample. A volume file is required to use volume variables."
                 ) from None
             volume_fld = [
                 fd
-                for fd in sample_metadata.get("volume").get("fields")
+                for fd in sample_metadata["volume"].get("fields")
                 if fd.get("name") in self.output.volume
             ]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -502,14 +502,9 @@ def test_throw_error_when_volume_is_missing_from_sample(simai_client):
 
     project.verify_gc_formula = Mock()
 
-    model_input = ModelInput(surface=[], boundary_conditions=["Vx"])
-    model_output = ModelOutput(surface=["Pressure", "WallShearStress_0"], volume=["Velocity_0"])
-    global_coefficients = [("max(Pressure)", "maxpress")]
-    simulation_volume = {
-        "X": {"length": 300.0, "type": "relative_to_min", "value": 15.0},
-        "Y": {"length": 80.0, "type": "absolute", "value": -80},
-        "Z": {"length": 40.0, "type": "absolute", "value": -20.0},
-    }
+    model_input = ModelInput(surface=[], boundary_conditions=[])
+    model_output = ModelOutput(surface=[], volume=["Velocity_0"])
+    global_coefficients = []
 
     model_conf = ModelConfiguration(
         project=project,
@@ -518,7 +513,6 @@ def test_throw_error_when_volume_is_missing_from_sample(simai_client):
         input=model_input,
         output=model_output,
         global_coefficients=global_coefficients,
-        simulation_volume=simulation_volume,
     )
 
     with pytest.raises(ProcessingError):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -475,3 +475,51 @@ def test_sse_event_handler(simai_client, model_factory):
         }
     )
     assert model.is_ready
+
+
+def test_throw_error_when_volume_is_missing_from_sample(simai_client):
+    """WHEN there is no volume in the extracted_metadata of the reference sample
+    AND the volume variables are set as model output
+    THEN a ProcessingError is thrown.
+    """
+
+    raw_project = {
+        "id": MODEL_RAW["project_id"],
+        "name": "fifi",
+        "sample": SAMPLE_RAW,
+    }
+
+    raw_project["sample"]["extracted_metadata"].pop("volume")
+
+    responses.add(
+        responses.GET,
+        f"https://test.test/projects/{MODEL_RAW['project_id']}",
+        json=raw_project,
+        status=200,
+    )
+
+    project: Project = simai_client._project_directory._model_from(raw_project)
+
+    project.verify_gc_formula = Mock()
+
+    model_input = ModelInput(surface=[], boundary_conditions=["Vx"])
+    model_output = ModelOutput(surface=["Pressure", "WallShearStress_0"], volume=["Velocity_0"])
+    global_coefficients = [("max(Pressure)", "maxpress")]
+    simulation_volume = {
+        "X": {"length": 300.0, "type": "relative_to_min", "value": 15.0},
+        "Y": {"length": 80.0, "type": "absolute", "value": -80},
+        "Z": {"length": 40.0, "type": "absolute", "value": -20.0},
+    }
+
+    model_conf = ModelConfiguration(
+        project=project,
+        build_preset="debug",
+        continuous=False,
+        input=model_input,
+        output=model_output,
+        global_coefficients=global_coefficients,
+        simulation_volume=simulation_volume,
+    )
+
+    with pytest.raises(ProcessingError):
+        model_conf._to_payload()


### PR DESCRIPTION
### Description

When a _volume_ variable is set as model output but no _volume_ exists in the reference sample, the program raises an exception that is not informative for the client. 

This fix raises an `ProcessingError` exception with an informative message. If _volume_ is set as an empty list (instead of `None`) while no _volume_ exists in the sample, no error is raised.

story: sc-23341