### PR TITLE
fix: optimization failing on Mode.success

### DIFF
--- a/src/ansys/simai/core/data/optimizations.py
+++ b/src/ansys/simai/core/data/optimizations.py
@@ -186,9 +186,7 @@ class OptimizationDirectory(Directory[Optimization]):
             geometry_parameters = optimization.fields["initial_geometry_parameters"]
             logger.debug("Optimization defined. Starting optimization loop.")
             iterations_results: List[Dict] = []
-            with keep.running(on_fail="warn") as k:
-                if not k.success:
-                    logger.info("Failed to get sleep inhibition lock.")
+            with keep.running(on_fail="warn"):
                 while geometry_parameters:
                     logger.debug(f"Generating geometry with parameters {geometry_parameters}.")
                     progress_bar.set_description("Generating geometry.")


### PR DESCRIPTION
Seems success() is gone in the latest versions of wakepy