### PR TITLE
build preset to take only supported values

### DIFF
--- a/src/ansys/simai/core/data/model_configuration.py
+++ b/src/ansys/simai/core/data/model_configuration.py
@@ -217,11 +217,11 @@ class ModelConfiguration:
 
                     | *debug*: < 30 min, only 4 dat
 
-                    | *short*: < 24 hours
+                    | *1_day*: < 24 hours
 
-                    | *default*: < 2 days, default value.
+                    | *2_days*: < 2 days, default value.
 
-                    | *long*: < 1 week
+                    | *7_days*: < 1 week
         continuous: indicates if continuous learning is enabled. Default is False.
         input: the inputs of the model.
         output: the outputs of the model.

--- a/src/ansys/simai/core/data/model_configuration.py
+++ b/src/ansys/simai/core/data/model_configuration.py
@@ -28,6 +28,13 @@ from ansys.simai.core.errors import InvalidArguments, ProcessingError
 if TYPE_CHECKING:
     from ansys.simai.core.data.projects import Project
 
+SupportedBuildPresets = {
+    "debug": "debug",
+    "1_day": "short",
+    "2_days": "default",
+    "7_days": "long",
+}
+
 
 @dataclass
 class DomainAxisDefinition:
@@ -280,12 +287,6 @@ class ModelConfiguration:
     """
 
     project: "Optional[Project]" = None
-    build_preset: Literal[
-        "debug",
-        "short",
-        "default",
-        "long",
-    ] = "default"
     continuous: bool = False
     input: ModelInput = field(default_factory=lambda: ModelInput())
     output: ModelOutput = field(default_factory=lambda: ModelOutput())
@@ -313,11 +314,26 @@ class ModelConfiguration:
 
     global_coefficients: list[GlobalCoefficientDefinition] = property(__get_gc, __set_gc)
 
+    def __validate_build_preset(self, val: str):
+        if val not in SupportedBuildPresets:
+            raise InvalidArguments(
+                f"Invalid value for build_preset, build_preset should be one of {list(SupportedBuildPresets.keys())}"
+            )
+
+    def __set_build_preset(self, val: str):
+        self.__validate_build_preset(val)
+        self.__dict__["build_preset"] = val
+
+    def __get_build_preset(self):
+        return self.__dict__.get("build_preset")
+
+    build_preset = property(__get_build_preset, __set_build_preset)
+
     def __init__(
         self,
         project: "Project",
         boundary_conditions: Optional[dict[str, Any]] = None,
-        build_preset: Optional[str] = None,
+        build_preset: Optional[str] = "debug",
         continuous: bool = False,
         fields: Optional[dict[str, Any]] = None,
         global_coefficients: Optional[list[GlobalCoefficientDefinition]] = None,
@@ -441,7 +457,7 @@ class ModelConfiguration:
 
         return {
             "boundary_conditions": bcs,
-            "build_preset": self.build_preset,
+            "build_preset": SupportedBuildPresets[self.build_preset],
             "continuous": self.continuous,
             "fields": flds,
             "global_coefficients": gcs,
@@ -462,3 +478,5 @@ class ModelConfiguration:
             )
             for gc in self.global_coefficients
         ]
+
+    del __set_build_preset, __get_build_preset

--- a/tests/test_model_configuration.py
+++ b/tests/test_model_configuration.py
@@ -23,7 +23,7 @@
 
 import pytest
 
-from ansys.simai.core.data.model_configuration import ModelConfiguration
+from ansys.simai.core.data.model_configuration import ModelConfiguration, SupportedBuildPresets
 from ansys.simai.core.errors import InvalidArguments
 
 
@@ -38,8 +38,10 @@ def test_build_preset_error(simai_client):
 
     project = simai_client._project_directory._model_from(raw_project)
 
-    with pytest.raises(InvalidArguments):
+    with pytest.raises(InvalidArguments) as excinfo:
         ModelConfiguration(
             project=project,
-            build_preset="not_valid",
+            build_preset="not_valid_value",
         )
+
+        assert f"{list(SupportedBuildPresets)}" in excinfo.value

--- a/tests/test_model_configuration.py
+++ b/tests/test_model_configuration.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import pytest
+
+from ansys.simai.core.data.model_configuration import ModelConfiguration
+from ansys.simai.core.errors import InvalidArguments
+
+
+def test_build_preset_error(simai_client):
+    """WHEN build_preset gets a non-supported value
+    THEN an InvalidArgument is raised."""
+
+    raw_project = {
+        "id": "xX007Xx",
+        "name": "fifi",
+    }
+
+    project = simai_client._project_directory._model_from(raw_project)
+
+    with pytest.raises(InvalidArguments):
+        ModelConfiguration(
+            project=project,
+            build_preset="not_valid",
+        )


### PR DESCRIPTION
## Description

This PR forces the value of `build_preset` in model configuration to be one of the supported values. 

When the user sets a non supported values in `build_preset`, an `InvalidArgument` error gets raised.

Story: [sc-24065]