### PR TITLE
Automorphing sdk

### DIFF
--- a/src/ansys/simai/core/api/optimization.py
+++ b/src/ansys/simai/core/api/optimization.py
@@ -29,10 +29,10 @@ class OptimizationClientMixin(ApiClientMixin):
     def define_optimization(self, workspace_id: str, optimization_parameters: Dict):
         return self._post(f"workspaces/{workspace_id}/optimizations", json=optimization_parameters)
 
-    def run_optimization_trial(self, optimization_id: str, geometry_parameters: Dict):
+    def run_optimization_trial(self, optimization_id: str, optimization_parameters: Dict):
         return self._post(
             f"optimizations/{optimization_id}/trial-runs",
-            json=geometry_parameters,
+            json=optimization_parameters,
         )
 
     def run_automorphism_trial(self, optimization_id: str):

--- a/src/ansys/simai/core/api/optimization.py
+++ b/src/ansys/simai/core/api/optimization.py
@@ -29,12 +29,15 @@ class OptimizationClientMixin(ApiClientMixin):
     def define_optimization(self, workspace_id: str, optimization_parameters: Dict):
         return self._post(f"workspaces/{workspace_id}/optimizations", json=optimization_parameters)
 
-    def run_optimization_trial(
-        self, optimization_id: str, geometry_id: str, geometry_parameters: Dict
-    ):
+    def run_optimization_trial(self, optimization_id: str, geometry_parameters: Dict):
         return self._post(
-            f"optimizations/{optimization_id}/trial-runs/{geometry_id}",
+            f"optimizations/{optimization_id}/trial-runs",
             json=geometry_parameters,
+        )
+
+    def run_automorphism_trial(self, optimization_id: str):
+        return self._post(
+            f"optimizations/{optimization_id}/trial-runs",
         )
 
     def get_optimization(self, optimization_id: str):


### PR DESCRIPTION
[WIP]
## Execution

```
ws = simai.workspaces.get(name="parametric-optim")
simai = sdk.from_config(profile="dev1", workspace=ws.name)
```
### Parametric 
```
def my_geometry_generation_function(param_a, param_b):
    filename = os.path.join(os.getcwd(),"test_geo", f"parametric-1_{dt.now()}_{param_a}_{param_b}.vtp")
    pv.read(os.path.join(os.getcwd(),"test_geo", "param-1.vtp")).save(filename)
    return filename


results = simai.optimizations.run_parametric(
    geometry_generation_fn=my_geometry_generation_function,
    geometry_parameters={
                "param_a": {"bounds": [-2.079, 1.0]},
                "param_b": {"bounds": [2.079, 9.0]},
            },
    minimize=["maxmagn"],
    boundary_conditions={"i": 3.0},
    outcome_constraints=[],
    n_iters=3,
)
```


### Non-parametric


```
geometry = simai.geometries.get(id="z196b31q")
ws = simai.workspaces.get(name="iason-ps9-dir")

results = simai.optimizations.run_non_parametric(
    geometry=geometry,
    workspace=ws,
    box_bounds_list=[[2.75, 3.25, -0.95, 0.95, -0.05, 0.8],
                     [0.47, 2.48, 15.5, 16.5, 0.145, 0.164]],
    symmetries=["x"],
    minimize=["gc_one"],
    boundary_conditions={"Vx": -5.0},
    n_iters=10,
)
```

## Tasks
✅ Endpoints: `define_optimization`, `run_optimization_trial`, `run_automorphism_trial`
✅ Methods: `run_parametric()`, `run_non_parametric()`, `OptimizationTrialRunDirectory._try()`
☐ `optimization_parameters` json <-> api schema match when calling `run_optimization_trial()`