### PR TITLE
Print out resolution when it exists

### DIFF
--- a/src/ansys/simai/core/utils/requests.py
+++ b/src/ansys/simai/core/utils/requests.py
@@ -70,7 +70,7 @@ def handle_http_errors(response: requests.Response) -> None:
                 raise NotFoundError(f"{message}", response) from e
             else:
                 raise ApiClientError(
-                    f"{response.status_code} {message}",
+                    f"{response.status_code} {message}. {json_response.get('resolution', '')}",
                     response,
                 ) from e
         else:

--- a/src/ansys/simai/core/utils/requests.py
+++ b/src/ansys/simai/core/utils/requests.py
@@ -70,7 +70,7 @@ def handle_http_errors(response: requests.Response) -> None:
                 raise NotFoundError(f"{message}", response) from e
             else:
                 raise ApiClientError(
-                    f"{response.status_code} {message}. {json_response.get('resolution', '')}",
+                    f"{response.status_code} {message}.\n{json_response.get('resolution', '')}",
                     response,
                 ) from e
         else:

--- a/src/ansys/simai/core/utils/requests.py
+++ b/src/ansys/simai/core/utils/requests.py
@@ -69,8 +69,11 @@ def handle_http_errors(response: requests.Response) -> None:
             if response.status_code == 404:
                 raise NotFoundError(f"{message}", response) from e
             else:
+                error_message = f"{response.status_code} {message}"
+                if resolution := json_response.get("resolution", ""):
+                    error_message += f"\n{resolution}"
                 raise ApiClientError(
-                    f"{response.status_code} {message}.\n{json_response.get('resolution', '')}",
+                    error_message,
                     response,
                 ) from e
         else:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -631,7 +631,7 @@ def test_failed_build_with_resolution(simai_client):
                 {
                     "id": "2a324",
                     "name": "td-987",
-                    "msg": "Missing fields: p (volume), p_rgh (volume)",
+                    "message": "Missing fields: p (volume), p_rgh (volume)",
                 }
             ]
         },


### PR DESCRIPTION
## Description

This PR prints out the resolution when it exists in the response body. In this way, the customer gets a guidance on how to fix the issue. 

Example of the error message after a build request in case of volume overflow:
<img width="1171" alt="print_out_resolution" src="https://github.com/user-attachments/assets/b302c4a1-ebc9-457c-8178-1421a66a7643">


Story: [sc-24307]

## Test
- unit test added
- smoke test against dev