### PR TITLE
Fix examples

### DIFF
--- a/src/ansys/simai/core/client.py
+++ b/src/ansys/simai/core/client.py
@@ -294,7 +294,7 @@ class SimAIClient:
 
                 import ansys.simai.core
 
-                simai = ansys.simai.core_from_config()
+                simai = ansys.simai.core.from_config()
 
         Note:
             The default paths are only supported on Unix systems.

--- a/src/ansys/simai/core/data/post_processings.py
+++ b/src/ansys/simai/core/data/post_processings.py
@@ -743,7 +743,7 @@ class PostProcessingDirectory(Directory[PostProcessing]):
 
                 import ansys.simai.core
 
-                simai = ansys.simai.core_from_config()
+                simai = ansys.simai.core.from_config()
                 prediction = simai.predictions.list()[0]
                 post_processings = simai.post_processings.list(
                     ansys.simai.core.SurfaceEvol, prediction.id
@@ -794,7 +794,7 @@ class PostProcessingDirectory(Directory[PostProcessing]):
 
                 import ansys.simai.core
 
-                simai = ansys.simai.core_from_config()
+                simai = ansys.simai.core.from_config()
                 prediction = simai.predictions.list()[0]
                 simai.post_processings.run(
                     ansys.simai.core.Slice, prediction, {"axis": "x", coordinate: 50}

--- a/src/ansys/simai/core/data/workspaces.py
+++ b/src/ansys/simai/core/data/workspaces.py
@@ -152,7 +152,7 @@ class WorkspaceDirectory(Directory[Workspace]):
 
             import ansys.simai.core
 
-            simai = ansys.simai.core_from_config()
+            simai = ansys.simai.core.from_config()
             simai.workspaces.list()
     """
 


### PR DESCRIPTION
Some examples of the documentation present the following line of code:
```
simai = ansys.simai.core_from_config()
```

Which returns the following error:
```
Fix AttributeError: module 'ansys.simai' has no attribute 'core_from_config'
```

This PR fixes that.