### PR TITLE
Raise an error when a variable is not found in the reference sample

### DIFF
--- a/src/ansys/simai/core/data/model_configuration.py
+++ b/src/ansys/simai/core/data/model_configuration.py
@@ -289,10 +289,7 @@ class ModelConfiguration:
 
     project: "Optional[Project]" = None
     continuous: bool = False
-    input: ModelInput = field(default_factory=lambda: ModelInput())
-    output: ModelOutput = field(default_factory=lambda: ModelOutput())
     domain_of_analysis: DomainOfAnalysis = field(default_factory=lambda: DomainOfAnalysis())
-    pp_input: PostProcessInput = field(default_factory=lambda: PostProcessInput())
 
     def __set_gc(self, gcs: list[GlobalCoefficientDefinition]):
         verified_gcs = []
@@ -329,6 +326,72 @@ class ModelConfiguration:
         return self.__dict__.get("build_preset")
 
     build_preset = property(__get_build_preset, __set_build_preset)
+
+    def __validate_variables(self, vars_to_validate: list[str], var_type: str):
+        sample_metadata = self.project.sample.fields.get("extracted_metadata")
+        var_fields = dict_get(sample_metadata, var_type, "fields", default=[])
+        var_fields_name = {fd.get("name") for fd in var_fields}
+        unknown_variables = set(vars_to_validate) - var_fields_name
+        if unknown_variables:
+            raise ProcessingError(
+                f"{self.__class__.__name__}: {var_type} variables {', '.join(unknown_variables)} do not exist in the reference sample."
+            ) from None
+
+    def __validate_surface_variables(self, vars_to_validate: list[str]):
+        sample_metadata = self.project.sample.fields.get("extracted_metadata")
+        if not sample_metadata.get("volume"):
+            raise ProcessingError(
+                "No volume file was found in the reference sample. A volume file is required to use volume variables."
+            ) from None
+        self.__validate_variables(vars_to_validate, "surface")
+
+    def __validate_volume_variables(self, vars_to_validate: list[str]):
+        sample_metadata = self.project.sample.fields.get("extracted_metadata")
+        if not sample_metadata.get("volume"):
+            raise ProcessingError(
+                "No volume file was found in the reference sample. A volume file is required to use volume variables."
+            ) from None
+        self.__validate_variables(vars_to_validate, "volume")
+
+    def __set_input(self, model_input: ModelInput):
+        if not model_input:
+            model_input = ModelInput()
+        if model_input.surface:
+            self.__validate_surface_variables(model_input.surface)
+        self.__dict__["input"] = model_input
+
+    def __get_input(self):
+        return self.__dict__.get("input")
+
+    input = property(__get_input, __set_input)
+
+    def __set_output(self, model_output: ModelOutput):
+        if not model_output:
+            model_output = ModelOutput()
+        if model_output.surface:
+            self.__validate_surface_variables(model_output.surface)
+
+        if model_output.volume:
+            self.__validate_volume_variables(model_output.volume)
+
+        self.__dict__["output"] = model_output
+
+    def __get_output(self):
+        return self.__dict__.get("output")
+
+    output = property(__get_output, __set_output)
+
+    def __set_pp_input(self, pp_input: PostProcessInput):
+        if not pp_input:
+            pp_input = PostProcessInput()
+        if pp_input.surface:
+            self.__validate_surface_variables(pp_input.surface)
+        self.__dict__["pp_input"] = pp_input
+
+    def __get_pp_input(self):
+        return self.__dict__.get("pp_input")
+
+    pp_input = property(__get_pp_input, __set_pp_input)
 
     def __init__(
         self,
@@ -408,34 +471,22 @@ class ModelConfiguration:
             bcs = {bc_name: {} for bc_name in self.input.boundary_conditions}
 
         sample_metadata = self.project.sample.fields.get("extracted_metadata")
+        surface_fields = dict_get(sample_metadata, "surface", "fields", default=[])
+        volume_fields = dict_get(sample_metadata, "volume", "fields", default=[])
 
         surface_input_fld = []
         if self.input.surface is not None:
             surface_input_fld = [
-                fd
-                for fd in sample_metadata.get("surface").get("fields")
-                if fd.get("name") in self.input.surface
+                fd for fd in surface_fields if fd.get("name") in self.input.surface
             ]
 
         surface_fld = []
         if self.output.surface is not None:
-            surface_fld = [
-                fd
-                for fd in sample_metadata.get("surface").get("fields")
-                if fd.get("name") in self.output.surface
-            ]
+            surface_fld = [fd for fd in surface_fields if fd.get("name") in self.output.surface]
 
         volume_fld = []
         if self.output.volume:
-            if not sample_metadata.get("volume"):
-                raise ProcessingError(
-                    "No volume file was found in the reference sample. A volume file is required to use volume variables."
-                ) from None
-            volume_fld = [
-                fd
-                for fd in sample_metadata["volume"].get("fields")
-                if fd.get("name") in self.output.volume
-            ]
+            volume_fld = [fd for fd in volume_fields if fd.get("name") in self.output.volume]
 
         gcs = []
         if self.global_coefficients is not None:
@@ -443,9 +494,8 @@ class ModelConfiguration:
 
         surface_pp_input_fld = []
         if self.pp_input.surface is not None:
-            suface_fields = dict_get(sample_metadata, "surface", "fields", default=[])
             surface_pp_input_fld = [
-                fd for fd in suface_fields if fd.get("name") in self.pp_input.surface
+                fd for fd in surface_fields if fd.get("name") in self.pp_input.surface
             ]
 
         flds = {

--- a/src/ansys/simai/core/data/model_configuration.py
+++ b/src/ansys/simai/core/data/model_configuration.py
@@ -339,9 +339,9 @@ class ModelConfiguration:
 
     def __validate_surface_variables(self, vars_to_validate: list[str]):
         sample_metadata = self.project.sample.fields.get("extracted_metadata")
-        if not sample_metadata.get("volume"):
+        if not sample_metadata.get("surface"):
             raise ProcessingError(
-                "No volume file was found in the reference sample. A volume file is required to use volume variables."
+                "No surface field is found in the reference sample. A surface field is required to use surface variables."
             ) from None
         self.__validate_variables(vars_to_validate, "surface")
 
@@ -349,13 +349,15 @@ class ModelConfiguration:
         sample_metadata = self.project.sample.fields.get("extracted_metadata")
         if not sample_metadata.get("volume"):
             raise ProcessingError(
-                "No volume file was found in the reference sample. A volume file is required to use volume variables."
+                "No volume field is found in the reference sample. A volume field is required to use volume variables."
             ) from None
         self.__validate_variables(vars_to_validate, "volume")
 
     def __set_input(self, model_input: ModelInput):
         if not model_input:
-            model_input = ModelInput()
+            raise InvalidArguments(
+                "Invalid value for input; input should be an instance of ModelInput."
+            )
         if model_input.surface:
             self.__validate_surface_variables(model_input.surface)
         self.__dict__["input"] = model_input
@@ -367,7 +369,9 @@ class ModelConfiguration:
 
     def __set_output(self, model_output: ModelOutput):
         if not model_output:
-            model_output = ModelOutput()
+            raise InvalidArguments(
+                "Invalid value for output; output should be an instance of ModelOutput."
+            )
         if model_output.surface:
             self.__validate_surface_variables(model_output.surface)
 

--- a/src/ansys/simai/core/data/model_configuration.py
+++ b/src/ansys/simai/core/data/model_configuration.py
@@ -92,7 +92,7 @@ class DomainAxisDefinition:
         if val < 0 and self.position != "absolute":
             raise InvalidArguments(
                 f"{self.__class__.__name__}: 'value' must be a positive number when the position is not 'absolute'.",
-            ) from None
+            )
 
     def __set_length(self, lgth: float):
         self.__validate_length(lgth)
@@ -105,7 +105,7 @@ class DomainAxisDefinition:
         if not lgth > 0:
             raise InvalidArguments(
                 f"{self.__class__.__name__}: 'length' must be a positive number.",
-            ) from None
+            )
 
     position: Literal["relative_to_min", "relative_to_max", "relative_to_center", "absolute"]
     value: float = property(__get_value, __set_value)
@@ -299,7 +299,7 @@ class ModelConfiguration:
             if self.project is None:
                 raise ProcessingError(
                     f"{self.__class__.__name__}: a project must be defined for setting global coefficients."
-                ) from None
+                )
 
             self.project.verify_gc_formula(
                 gc_unit.formula, self.input.boundary_conditions, self.output.surface
@@ -335,14 +335,14 @@ class ModelConfiguration:
         if unknown_variables:
             raise ProcessingError(
                 f"{self.__class__.__name__}: {var_type} variables {', '.join(unknown_variables)} do not exist in the reference sample."
-            ) from None
+            )
 
     def __validate_surface_variables(self, vars_to_validate: list[str]):
         sample_metadata = self.project.sample.fields.get("extracted_metadata")
         if not sample_metadata.get("surface"):
             raise ProcessingError(
                 "No surface field is found in the reference sample. A surface field is required to use surface variables."
-            ) from None
+            )
         self.__validate_variables(vars_to_validate, "surface")
 
     def __validate_volume_variables(self, vars_to_validate: list[str]):
@@ -350,7 +350,7 @@ class ModelConfiguration:
         if not sample_metadata.get("volume"):
             raise ProcessingError(
                 "No volume field is found in the reference sample. A volume field is required to use volume variables."
-            ) from None
+            )
         self.__validate_variables(vars_to_validate, "volume")
 
     def __set_input(self, model_input: ModelInput):
@@ -541,7 +541,7 @@ class ModelConfiguration:
         if self.project is None:
             raise ProcessingError(
                 f"{self.__class__.__name__}: a project must be a defined for computing the global coefficient formula."
-            ) from None
+            )
 
         return [
             self.project.compute_gc_formula(

--- a/tests/test_model_configuration.py
+++ b/tests/test_model_configuration.py
@@ -45,3 +45,41 @@ def test_build_preset_error(simai_client):
         )
 
         assert f"{list(SupportedBuildPresets)}" in excinfo.value
+
+
+def test_model_input_not_none(simai_client):
+    """WHEN ModelConfiguration.input gets a None value
+    THEN an InvalidArgument is raised."""
+
+    raw_project = {
+        "id": "xX007Xx",
+        "name": "fifi",
+    }
+
+    project = simai_client._project_directory._model_from(raw_project)
+
+    bld_conf = ModelConfiguration(
+        project=project,
+    )
+
+    with pytest.raises(InvalidArguments):
+        bld_conf.input = None
+
+
+def test_model_output_not_none(simai_client):
+    """WHEN ModelConfiguration.input gets a None value
+    THEN an InvalidArgument is raised."""
+
+    raw_project = {
+        "id": "xX007Xx",
+        "name": "fifi",
+    }
+
+    project = simai_client._project_directory._model_from(raw_project)
+
+    bld_conf = ModelConfiguration(
+        project=project,
+    )
+
+    with pytest.raises(InvalidArguments):
+        bld_conf.output = None


### PR DESCRIPTION
## Description

When an input/output/pp_input variable is introduced, the SDK now would validate that the variables exist in the reference sample. Otherwise, it would raise an error. The validation occurs upon assignment. 

This PR also does some small code improvements in `ModelConfiguration._to_payload`.

Story: sc-24993

### Example of the raised error
![image](https://github.com/user-attachments/assets/d3496f54-2138-4685-bf42-eeb1909bc9cb)

## Test
- Corresponding unit-test adding