### PR TITLE
Check new version from pypi instead of our api: fix pysimai version check

### DIFF
--- a/src/ansys/simai/core/client.py
+++ b/src/ansys/simai/core/client.py
@@ -24,7 +24,6 @@ import logging
 from typing import List, Optional
 
 from pydantic import ValidationError
-from semver.version import Version
 
 from ansys.simai.core import __version__
 from ansys.simai.core.api.client import ApiClient
@@ -54,6 +53,7 @@ from ansys.simai.core.errors import (
 )
 from ansys.simai.core.utils.config_file import get_config
 from ansys.simai.core.utils.configuration import ClientConfig
+from ansys.simai.core.utils.misc import warn_package_outdated
 from ansys.simai.core.utils.typing import steal_kwargs_type_on_method
 
 logger = logging.getLogger(__name__)
@@ -324,26 +324,15 @@ class SimAIClient:
                 raise errors[0]
             raise MultipleErrors(errors)
 
-    def _check_for_new_version(self, client_name="ansys.simai.core", current_version=__version__):
+    def _check_for_new_version(self) -> None:
         try:
-            latest_version = self._api._get(f"info/{client_name}/version")["version"]
-            version_current = Version.parse(current_version)
-            version_latest = Version.parse(latest_version)
-        except (SimAIError, ValueError):
-            pass
-        else:
-            if version_current < version_latest:
-                warn_template = (
-                    f"A new version of {client_name} is %s. "
-                    "Upgrade to get new features and ensure compatibility with the server."
-                )
-                if (
-                    version_current.major < version_latest.major
-                    or version_current.minor < version_latest.minor
-                ):
-                    raise SimAIError(warn_template % "required")
-                else:
-                    logger.warning(warn_template % "available")
+            latest_version = self._api._get("https://pypi.org/pypi/ansys-simai-core/json")["info"][
+                "version"
+            ]
+        except (SimAIError, KeyError) as e:
+            logger.debug(f"Could not query package version on pypi: {e}")
+            return None
+        warn_package_outdated("ansys-simai-core", __version__, latest_version)
 
 
 from_config = SimAIClient.from_config

--- a/src/ansys/simai/core/client.py
+++ b/src/ansys/simai/core/client.py
@@ -53,7 +53,7 @@ from ansys.simai.core.errors import (
 )
 from ansys.simai.core.utils.config_file import get_config
 from ansys.simai.core.utils.configuration import ClientConfig
-from ansys.simai.core.utils.misc import warn_package_outdated
+from ansys.simai.core.utils.misc import notify_if_package_outdated
 from ansys.simai.core.utils.typing import steal_kwargs_type_on_method
 
 logger = logging.getLogger(__name__)
@@ -332,7 +332,7 @@ class SimAIClient:
         except (SimAIError, KeyError) as e:
             logger.debug(f"Could not query package version on pypi: {e}")
             return None
-        warn_package_outdated("ansys-simai-core", __version__, latest_version)
+        notify_if_package_outdated("ansys-simai-core", __version__, latest_version)
 
 
 from_config = SimAIClient.from_config

--- a/src/ansys/simai/core/utils/misc.py
+++ b/src/ansys/simai/core/utils/misc.py
@@ -66,6 +66,6 @@ def warn_package_outdated(package: str, current_version: str, latest_version: st
                 version_current.major < version_latest.major
                 or version_current.minor < version_latest.minor
             ):
-                raise SimAIError(warn_template % "required")
+                logger.critical(warn_template % "required")
             else:
                 logger.warning(warn_template % "available")

--- a/src/ansys/simai/core/utils/misc.py
+++ b/src/ansys/simai/core/utils/misc.py
@@ -21,7 +21,14 @@
 # SOFTWARE.
 
 import getpass
+import logging
 from typing import Any, Dict, Optional
+
+from semver.version import Version
+
+from ansys.simai.core.errors import SimAIError
+
+logger = logging.getLogger(__name__)
 
 
 def prompt_for_input(name: str, hide_input: Optional[bool] = False):
@@ -41,3 +48,24 @@ def dict_get(obj: dict, *keys: str, default=None):
     for k in keys:
         obj = obj.get(k, {}) or {}
     return obj or default
+
+
+def warn_package_outdated(package: str, current_version: str, latest_version: str):
+    try:
+        version_current = Version.parse(current_version)
+        version_latest = Version.parse(latest_version)
+    except ValueError as e:
+        logger.debug(f"Could not parse package version: {e}")
+    else:
+        if version_current < version_latest:
+            warn_template = (
+                f"A new version of {package} is %s. "
+                "Upgrade to get new features and ensure compatibility with the server."
+            )
+            if (
+                version_current.major < version_latest.major
+                or version_current.minor < version_latest.minor
+            ):
+                raise SimAIError(warn_template % "required")
+            else:
+                logger.warning(warn_template % "available")

--- a/src/ansys/simai/core/utils/misc.py
+++ b/src/ansys/simai/core/utils/misc.py
@@ -26,8 +26,6 @@ from typing import Any, Dict, Optional
 
 from semver.version import Version
 
-from ansys.simai.core.errors import SimAIError
-
 logger = logging.getLogger(__name__)
 
 
@@ -50,7 +48,7 @@ def dict_get(obj: dict, *keys: str, default=None):
     return obj or default
 
 
-def warn_package_outdated(package: str, current_version: str, latest_version: str):
+def notify_if_package_outdated(package: str, current_version: str, latest_version: str):
     try:
         version_current = Version.parse(current_version)
         version_latest = Version.parse(latest_version)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,21 +41,14 @@ def test_client_creation_invalid_config():
 
 @pytest.mark.parametrize(
     "local_ver,latest_ver,expected",
-
     [
         ("1.1.0", "1.1.1", "available."),
         ("1.0.9-rc8", "1.0.9", "available."),
         ("1.0.9", "1.9.0", "required."),
-     ]
+    ],
 )
 @responses.activate
-def test_client_version_auto_warn(
-    caplog,
-    mocker,
-    local_ver,
-    latest_ver,
-    expected
-):
+def test_client_version_auto_warn(caplog, mocker, local_ver, latest_ver, expected):
     """WHEN the SDK version is slightly outdated compared to what the API responds
     THEN a warning is printed
     """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import functools
 from pathlib import Path
 
 import pytest
@@ -46,13 +45,13 @@ def test_client_version_auto_warn(caplog, mocker):
     THEN a warning is printed
     """
     mocker.patch(
-        "ansys.simai.core.client.SimAIClient._check_for_new_version",
-        functools.partialmethod(SimAIClient._check_for_new_version, current_version="1.1.0"),
+        "ansys.simai.core.client.__version__",
+        "1.1.0",
     )
     responses.add(
         responses.GET,
-        "https://test.test/info/ansys.simai.core/version",
-        json={"version": "1.1.1"},
+        "https://pypi.org/pypi/ansys-simai-core/json",
+        json={"info": {"version": "1.1.1"}},
         status=200,
     )
     SimAIClient(
@@ -62,7 +61,7 @@ def test_client_version_auto_warn(caplog, mocker):
         no_sse_connection=True,
         skip_version_check=False,
     )
-    assert "A new version of ansys.simai.core is available" in caplog.text
+    assert "A new version of ansys-simai-core is available" in caplog.text
 
 
 @responses.activate
@@ -71,13 +70,14 @@ def test_client_version_auto_error(caplog, mocker):
     THEN an exception is raised
     """
     mocker.patch(
-        "ansys.simai.core.client.SimAIClient._check_for_new_version",
-        functools.partialmethod(SimAIClient._check_for_new_version, current_version="1.0.9-rc8"),
+        "ansys.simai.core.client.__version__",
+        "1.0.9-rc8",
     )
+
     responses.add(
         responses.GET,
-        "https://test.test/info/ansys.simai.core/version",
-        json={"version": "1.9.0"},
+        "https://pypi.org/pypi/ansys-simai-core/json",
+        json={"info": {"version": "1.9.0"}},
         status=200,
     )
     with pytest.raises(err.SimAIError) as exc:
@@ -88,4 +88,4 @@ def test_client_version_auto_error(caplog, mocker):
             no_sse_connection=True,
             skip_version_check=False,
         )
-    assert "A new version of ansys.simai.core is required" in str(exc.value)
+    assert "A new version of ansys-simai-core is required" in str(exc.value)


### PR DESCRIPTION
:ticket:  https://app.shortcut.com/simai/story/26689/pysimai-fetch-latest-release-from-pypi

Our API stopped containing the latest pysimai version when it moved to this repo.
Since it's now on pypi we can just query there instead of querying our API.

I kept `warn_package_outdated` quite generic so internal packages can use it too (just like they did with `_check_for_new_version` before).