### PR TITLE
migrations for ansys-actions-v8

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -117,6 +117,8 @@ jobs:
       - uses: ansys/actions/doc-deploy-dev@v8
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-deploy-stable:
@@ -128,11 +130,15 @@ jobs:
       - uses: ansys/actions/doc-deploy-stable@v8
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: "Release to private and public PyPI and to GitHub"
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: [build-library]
     steps:
@@ -147,3 +153,4 @@ jobs:
         uses: ansys/actions/release-github@v8
         with:
           library-name: ${{ env.LIBRARY_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates Github's CI/CD actions as required for migrating to Ansys actions v8

story: [sc-27127]