### PR TITLE
[feat] Support post processing predict as learnt and predict on cells for surface variables

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -117,6 +117,8 @@ jobs:
       - uses: ansys/actions/doc-deploy-dev@v8
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-deploy-stable:
@@ -128,11 +130,15 @@ jobs:
       - uses: ansys/actions/doc-deploy-stable@v8
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: "Release to private and public PyPI and to GitHub"
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: [build-library]
     steps:
@@ -147,3 +153,4 @@ jobs:
         uses: ansys/actions/release-github@v8
         with:
           library-name: ${{ env.LIBRARY_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/source/api_reference/post_processings.rst
+++ b/doc/source/api_reference/post_processings.rst
@@ -56,6 +56,14 @@ Available postprocessings
     :members:
 
 
+.. autoclass:: PostProcessingOnCells()
+    :members:
+
+
+.. autoclass:: PostProcessingAsLearnt()
+    :members:
+
+
 .. autoclass:: VolumeVTU()
     :members:
 
@@ -68,4 +76,7 @@ Helpers
 -------
 
 .. autoclass:: DownloadableResult()
+    :members:
+
+.. autoclass:: PPSurfaceLocation()
     :members:

--- a/doc/source/api_reference/post_processings.rst
+++ b/doc/source/api_reference/post_processings.rst
@@ -52,11 +52,11 @@ Available postprocessings
     :members:
 
 
-.. autoclass:: PostProcessingOnCells()
+.. autoclass:: SurfaceVTP()
     :members:
 
 
-.. autoclass:: PostProcessingAsLearnt()
+.. autoclass:: SurfaceVTPTDLocation()
     :members:
 
 
@@ -72,7 +72,4 @@ Helpers
 -------
 
 .. autoclass:: DownloadableResult()
-    :members:
-
-.. autoclass:: PPSurfaceLocation()
     :members:

--- a/doc/source/api_reference/post_processings.rst
+++ b/doc/source/api_reference/post_processings.rst
@@ -52,10 +52,6 @@ Available postprocessings
     :members:
 
 
-.. autoclass:: SurfaceVTP()
-    :members:
-
-
 .. autoclass:: PostProcessingOnCells()
     :members:
 

--- a/src/ansys/simai/core/__init__.py
+++ b/src/ansys/simai/core/__init__.py
@@ -34,8 +34,9 @@ from ansys.simai.core.client import SimAIClient, from_config
 from ansys.simai.core.data.post_processings import (
     CustomVolumePointCloud,
     GlobalCoefficients,
+    PostProcessingAsLearnt,
+    PostProcessingOnCells,
     Slice,
     SurfaceEvol,
-    SurfaceVTP,
     VolumeVTU,
 )

--- a/src/ansys/simai/core/__init__.py
+++ b/src/ansys/simai/core/__init__.py
@@ -34,9 +34,9 @@ from ansys.simai.core.client import SimAIClient, from_config
 from ansys.simai.core.data.post_processings import (
     CustomVolumePointCloud,
     GlobalCoefficients,
-    PostProcessingAsLearnt,
-    PostProcessingOnCells,
     Slice,
     SurfaceEvol,
+    SurfaceVTP,
+    SurfaceVTPTDLocation,
     VolumeVTU,
 )

--- a/src/ansys/simai/core/data/post_processings.py
+++ b/src/ansys/simai/core/data/post_processings.py
@@ -268,14 +268,15 @@ class VolumeVTU(_PostProcessingVTKExport):
     """
 
 
-class SurfaceVTP(_PostProcessingVTKExport):
-    """Provides for exporting the surface of the prediction in VTP format.
+class _SurfaceVTP(_PostProcessingVTKExport):
+    """Exports the surface of the prediction in VTP format.
 
-    This class is generated through the :meth:`~PredictionPostProcessings.surface_vtp()` method.
+    This is the parent class for surface post-processings which are generated through
+    the :meth:`~PredictionPostProcessings.surface_vtp()` method.
     """
 
 
-class PostProcessingOnCells(SurfaceVTP):
+class PostProcessingOnCells(_SurfaceVTP):
     """Decodes the server response for the on-cells prediction of the surface in VTP format.
 
     This class is generated through the :meth:`~PredictionPostProcessings.surface_vtp()` method.
@@ -286,7 +287,7 @@ class PostProcessingOnCells(SurfaceVTP):
         return "SurfaceVTP"
 
 
-class PostProcessingAsLearnt(SurfaceVTP):
+class PostProcessingAsLearnt(_SurfaceVTP):
     """Decodes the server response for the as-learnt prediction of the surface in VTP format.
 
     This class is generated through the :meth:`~PredictionPostProcessings.surface_vtp()` method.
@@ -462,7 +463,7 @@ class PredictionPostProcessings:
 
     def surface_vtp(
         self, run: bool = True, pp_location: PPSurfaceLocation = PPSurfaceLocation.ON_CELLS
-    ) -> Optional[SurfaceVTP]:
+    ) -> Optional[_SurfaceVTP]:
         """Compute or get the result of the prediction's surface in VTP format.
 
         This is a non-blocking method. It returns the ``PostProcessingVTP``
@@ -484,7 +485,8 @@ class PredictionPostProcessings:
                 is raised. Default is PPSurfaceLocation.ON_CELLS.
 
         Returns:
-            :class:`SurfaceVTP` object that allows downloading the binary data.
+            :class:`PostProcessingOnCells` or :class:`PostProcessingAsLearnt` objects
+            that allows downloading the binary data.
             Returns ``None`` if ``run=False`` and the postprocessing does not exist.
 
         Examples:

--- a/src/ansys/simai/core/data/post_processings.py
+++ b/src/ansys/simai/core/data/post_processings.py
@@ -25,6 +25,7 @@ import logging
 import numbers
 import sys
 from abc import ABC, abstractmethod
+from enum import Enum
 from inspect import cleandoc
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
@@ -274,11 +275,38 @@ class SurfaceVTP(_PostProcessingVTKExport):
     """
 
 
-class SurfaceVTPTDLocation(_PostProcessingVTKExport):
-    """Provides exporting the surface of the prediction on the original data location (predict as learnt).
+class PostProcessingOnCells(SurfaceVTP):
+    """Decodes the server response for the on-cells prediction of the surface in VTP format.
 
-    This class is generated through the :meth:`~PredictionPostProcessings.predict_as_learnt()` method.
+    This class is generated through the :meth:`~PredictionPostProcessings.surface_vtp()` method.
     """
+
+    @classmethod
+    def _api_name(cls):
+        return "SurfaceVTP"
+
+
+class PostProcessingAsLearnt(SurfaceVTP):
+    """Decodes the server response for the as-learnt prediction of the surface in VTP format.
+
+    This class is generated through the :meth:`~PredictionPostProcessings.surface_vtp()` method.
+    """
+
+    @classmethod
+    def _api_name(cls):
+        return "SurfaceVTPTDLocation"
+
+
+class PPSurfaceLocation(Enum):
+    """Enumerates the post-processing options on the data location.
+
+    Args:
+        ON_CELLS: identifies that the post-processing should run on cell data.
+        AS_LEARNT: identifies that the post-processing should run on the data as they are learnt.
+    """
+
+    AS_LEARNT = PostProcessingAsLearnt
+    ON_CELLS = PostProcessingOnCells
 
 
 class CustomVolumePointCloud(PostProcessing):
@@ -432,7 +460,9 @@ class PredictionPostProcessings:
         plane = convert_axis_and_coordinate_to_plane_eq_coeffs(axis, coordinate)
         return self._get_or_run(Slice, {"plane": plane, "output_format": format}, run)
 
-    def surface_vtp(self, run: bool = True) -> Optional[SurfaceVTP]:
+    def surface_vtp(
+        self, run: bool = True, pp_location: PPSurfaceLocation = PPSurfaceLocation.ON_CELLS
+    ) -> Optional[SurfaceVTP]:
         """Compute or get the result of the prediction's surface in VTP format.
 
         This is a non-blocking method. It returns the ``PostProcessingVTP``
@@ -449,24 +479,42 @@ class PredictionPostProcessings:
             run: Boolean indicating whether to compute or get the postprocessing.
                 The default is ``True``. If ``False``, the postprocessing is not
                 computed, and ``None`` is returned if it does not exist yet.
+            pp_location: the post-processing data location. It can be one of
+                :class:`PPSurfaceLocation`, otherwise a nvalidArgument error
+                is raised. Default is PPSurfaceLocation.ON_CELLS.
 
         Returns:
             :class:`SurfaceVTP` object that allows downloading the binary data.
             Returns ``None`` if ``run=False`` and the postprocessing does not exist.
 
         Examples:
-            Run and download a surface VTP.
+            Run and download a surface VTP for data location on cells (predict on cells).
 
             .. code-block:: python
 
                 import ansys.simai.core
+                from ansys.simai.core.data.post_processings import PPSurfaceLocation
 
                 simai = ansys.simai.core.from_config()
                 prediction = simai.predictions.list()[0]
-                surface_vtp = prediction.post.surface_vtp().data.download("/tmp/simai.vtp")
+                surface_vtp = prediction.post.surface_vtp(
+                    pp_location=PPSurfaceLocation.ON_CELLS
+                ).data.download("/tmp/simai.vtp")
 
+            Run and download a surface VTP with data location as it is learnt (predict as learnt).
 
-            Run a surface VTP and open a plot using PyVista.
+            .. code-block:: python
+
+                import ansys.simai.core
+                from ansys.simai.core.data.post_processings import PPSurfaceLocation
+
+                simai = ansys.simai.core.from_config()
+                prediction = simai.predictions.list()[0]
+                surface_vtp = prediction.post.surface_vtp(
+                    pp_location=PPSurfaceLocation.AS_LEARNT
+                ).data.download("/tmp/simai.vtp")
+
+            Run a surface VTP with data location on cells, and open a plot using PyVista.
 
             .. code-block:: python
 
@@ -484,61 +532,9 @@ class PredictionPostProcessings:
                     surface_vtp = pyvista.read(temp_vtp_file.name)
                     surface_vtp.plot()
         """
-        return self._get_or_run(SurfaceVTP, {}, run)
-
-    def predict_as_learnt(self, run: bool = True) -> Optional[SurfaceVTP]:
-        """Compute or get the result of the prediction's as learnt.
-
-        This is a non-blocking method. It returns the ``PostProcessingVTP``
-        object without waiting. This object may not have data right away
-        if the computation is still in progress. Data is filled
-        asynchronously once the computation is finished.
-        The state of computation can be monitored with the ``is_ready`` flag
-        or waited upon with the ``wait()`` method.
-
-        The computation is launched only on first call of this method.
-        Subsequent calls do not relaunch it.
-
-        Args:
-            run: Boolean indicating whether to compute or get the postprocessing.
-                The default is ``True``. If ``False``, the postprocessing is not
-                computed, and ``None`` is returned if it does not exist yet.
-
-        Returns:
-            :class:`SurfaceVTP` object that allows downloading the binary data.
-            Returns ``None`` if ``run=False`` and the postprocessing does not exist.
-
-        Examples:
-            Run and download a surface VTP.
-
-            .. code-block:: python
-
-                import ansys.simai.core
-
-                simai = ansys.simai.core.from_config()
-                prediction = simai.predictions.list()[0]
-                surface_vtp = prediction.post.surface_vtp().data.download("/tmp/simai.vtp")
-
-
-            Run a surface VTP and open a plot using PyVista.
-
-            .. code-block:: python
-
-                import ansys.simai.core
-                import pyvista
-                import tempfile
-
-                simai = ansys.simai.core.from_config()
-                prediction = simai.predictions.list()[0]
-                surface_vtp_data = prediction.post.surface_vtp().data
-                # I don't want to save the file locally but pyvista doesn't read file-objects
-                # Using temporary file as a workaround but a real path can be used instead
-                with tempfile.NamedTemporaryFile(suffix=".vtp") as temp_vtp_file:
-                    surface_vtp_data.download(temp_vtp_file.name)
-                    surface_vtp = pyvista.read(temp_vtp_file.name)
-                    surface_vtp.plot()
-        """
-        return self._get_or_run(SurfaceVTPTDLocation, {}, run)
+        if not isinstance(pp_location, PPSurfaceLocation):
+            raise InvalidArguments(f"pp_location should be one of {PPSurfaceLocation}")
+        return self._get_or_run(pp_location.value, {}, run)
 
     def volume_vtu(self, run: bool = True) -> Optional[VolumeVTU]:
         """Compute or get the result of the prediction's volume in VTU format.

--- a/src/ansys/simai/core/data/post_processings.py
+++ b/src/ansys/simai/core/data/post_processings.py
@@ -270,8 +270,7 @@ class VolumeVTU(_PostProcessingVTKExport):
 class SurfaceVTP(_PostProcessingVTKExport):
     """Exports the surface of the prediction in VTP format associating all data with cells.
 
-    This is the parent class for surface post-processings which are generated through
-    the :meth:`~PredictionPostProcessings.surface_vtp()` method.
+    This class is generated through the :meth:`~PredictionPostProcessings.surface_vtp()` method.
     """
 
 
@@ -433,10 +432,7 @@ class PredictionPostProcessings:
         plane = convert_axis_and_coordinate_to_plane_eq_coeffs(axis, coordinate)
         return self._get_or_run(Slice, {"plane": plane, "output_format": format}, run)
 
-    def surface_vtp(
-        self,
-        run: bool = True,
-    ) -> Optional[SurfaceVTP]:
+    def surface_vtp(self, run: bool = True) -> Optional[SurfaceVTP]:
         """Compute or get the result of the prediction's surface in VTP format.
 
         This method associates all data with cells; if a variable is originally
@@ -458,7 +454,7 @@ class PredictionPostProcessings:
                 computed, and ``None`` is returned if it does not exist yet.
 
         Returns:
-            :class:`SurfaceVTP` objects that allow downloading the binary data.
+            :class:`SurfaceVTP` object that allows downloading the binary data.
             Returns ``None`` if ``run=False`` and the postprocessing does not exist.
 
         Examples:
@@ -472,7 +468,7 @@ class PredictionPostProcessings:
                 prediction = simai.predictions.list()[0]
                 surface_vtp = prediction.post.surface_vtp().data.download("/tmp/simai.vtp")
 
-            Run a surface VTP with data location on cells, and open a plot using PyVista.
+            Run a surface VTP with data association on cells, and open a plot using PyVista.
 
             .. code-block:: python
 
@@ -492,10 +488,7 @@ class PredictionPostProcessings:
         """
         return self._get_or_run(SurfaceVTP, {}, run)
 
-    def surface_vtp_td_location(
-        self,
-        run: bool = True,
-    ) -> Optional[SurfaceVTPTDLocation]:
+    def surface_vtp_td_location(self, run: bool = True) -> Optional[SurfaceVTPTDLocation]:
         """Compute or get the result of the prediction's surface in VTP format .
 
         This method keeps the original data association as they are in the sample.
@@ -516,11 +509,11 @@ class PredictionPostProcessings:
                 computed, and ``None`` is returned if it does not exist yet.
 
         Returns:
-            :class:`SurfaceVTPTDLocation` objects that allow downloading the binary data.
+            :class:`SurfaceVTPTDLocation` object that allows downloading the binary data.
             Returns ``None`` if ``run=False`` and the postprocessing does not exist.
 
         Examples:
-            Run and download a surface VTP.
+            Run and download a surface VTP with the original data association.
 
             .. code-block:: python
 
@@ -530,7 +523,7 @@ class PredictionPostProcessings:
                 prediction = simai.predictions.list()[0]
                 surface_vtp = prediction.post.surface_vtp_td_location().data.download("/tmp/simai.vtp")
 
-            Run a surface VTP with data location on cells, and open a plot using PyVista.
+            Run a surface VTP with the original data association, and open a plot using PyVista.
 
             .. code-block:: python
 

--- a/src/ansys/simai/core/data/post_processings.py
+++ b/src/ansys/simai/core/data/post_processings.py
@@ -274,6 +274,13 @@ class SurfaceVTP(_PostProcessingVTKExport):
     """
 
 
+class SurfaceVTPTDLocation(_PostProcessingVTKExport):
+    """Provides exporting the surface of the prediction on the original data location (predict as learnt).
+
+    This class is generated through the :meth:`~PredictionPostProcessings.predict_as_learnt()` method.
+    """
+
+
 class CustomVolumePointCloud(PostProcessing):
     """Provides a representation of a CustomVolumePointCloud post-processing.
 
@@ -478,6 +485,60 @@ class PredictionPostProcessings:
                     surface_vtp.plot()
         """
         return self._get_or_run(SurfaceVTP, {}, run)
+
+    def predict_as_learnt(self, run: bool = True) -> Optional[SurfaceVTP]:
+        """Compute or get the result of the prediction's as learnt.
+
+        This is a non-blocking method. It returns the ``PostProcessingVTP``
+        object without waiting. This object may not have data right away
+        if the computation is still in progress. Data is filled
+        asynchronously once the computation is finished.
+        The state of computation can be monitored with the ``is_ready`` flag
+        or waited upon with the ``wait()`` method.
+
+        The computation is launched only on first call of this method.
+        Subsequent calls do not relaunch it.
+
+        Args:
+            run: Boolean indicating whether to compute or get the postprocessing.
+                The default is ``True``. If ``False``, the postprocessing is not
+                computed, and ``None`` is returned if it does not exist yet.
+
+        Returns:
+            :class:`SurfaceVTP` object that allows downloading the binary data.
+            Returns ``None`` if ``run=False`` and the postprocessing does not exist.
+
+        Examples:
+            Run and download a surface VTP.
+
+            .. code-block:: python
+
+                import ansys.simai.core
+
+                simai = ansys.simai.core.from_config()
+                prediction = simai.predictions.list()[0]
+                surface_vtp = prediction.post.surface_vtp().data.download("/tmp/simai.vtp")
+
+
+            Run a surface VTP and open a plot using PyVista.
+
+            .. code-block:: python
+
+                import ansys.simai.core
+                import pyvista
+                import tempfile
+
+                simai = ansys.simai.core.from_config()
+                prediction = simai.predictions.list()[0]
+                surface_vtp_data = prediction.post.surface_vtp().data
+                # I don't want to save the file locally but pyvista doesn't read file-objects
+                # Using temporary file as a workaround but a real path can be used instead
+                with tempfile.NamedTemporaryFile(suffix=".vtp") as temp_vtp_file:
+                    surface_vtp_data.download(temp_vtp_file.name)
+                    surface_vtp = pyvista.read(temp_vtp_file.name)
+                    surface_vtp.plot()
+        """
+        return self._get_or_run(SurfaceVTPTDLocation, {}, run)
 
     def volume_vtu(self, run: bool = True) -> Optional[VolumeVTU]:
         """Compute or get the result of the prediction's volume in VTU format.

--- a/src/ansys/simai/core/data/post_processings.py
+++ b/src/ansys/simai/core/data/post_processings.py
@@ -480,7 +480,7 @@ class PredictionPostProcessings:
                 The default is ``True``. If ``False``, the postprocessing is not
                 computed, and ``None`` is returned if it does not exist yet.
             pp_location: the post-processing data location. It can be one of
-                :class:`PPSurfaceLocation`, otherwise a nvalidArgument error
+                :class:`PPSurfaceLocation`, otherwise an InvalidArgument error
                 is raised. Default is PPSurfaceLocation.ON_CELLS.
 
         Returns:

--- a/src/ansys/simai/core/data/post_processings.py
+++ b/src/ansys/simai/core/data/post_processings.py
@@ -310,6 +310,10 @@ class PPSurfaceLocation(Enum):
     ON_CELLS = PostProcessingOnCells
 
 
+SurfacePpOutputs = Union[PostProcessingOnCells, PostProcessingAsLearnt]
+"""Collection of surface post-processing outputs."""
+
+
 class CustomVolumePointCloud(PostProcessing):
     """Provides a representation of a CustomVolumePointCloud post-processing.
 
@@ -463,7 +467,7 @@ class PredictionPostProcessings:
 
     def surface_vtp(
         self, run: bool = True, pp_location: PPSurfaceLocation = PPSurfaceLocation.ON_CELLS
-    ) -> Optional[_SurfaceVTP]:
+    ) -> Optional[SurfacePpOutputs]:
         """Compute or get the result of the prediction's surface in VTP format.
 
         This is a non-blocking method. It returns the ``PostProcessingVTP``

--- a/src/ansys/simai/core/data/selection_post_processings.py
+++ b/src/ansys/simai/core/data/selection_post_processings.py
@@ -28,8 +28,8 @@ from ansys.simai.core.data.post_processings import (
     PPSurfaceLocation,
     Slice,
     SurfaceEvol,
+    SurfacePpOutputs,
     VolumeVTU,
-    _SurfaceVTP,
 )
 
 if TYPE_CHECKING:
@@ -147,7 +147,7 @@ class SelectionPostProcessingsMethods:
 
     def surface_vtp(
         self, pp_location: PPSurfaceLocation = PPSurfaceLocation.ON_CELLS
-    ) -> PPList[_SurfaceVTP]:
+    ) -> PPList[SurfacePpOutputs]:
         """Compute or get the result of each prediction's surface in the VTP format.
 
         This is a non-blocking method. It returns a

--- a/src/ansys/simai/core/data/selection_post_processings.py
+++ b/src/ansys/simai/core/data/selection_post_processings.py
@@ -25,10 +25,10 @@ from typing import TYPE_CHECKING
 from ansys.simai.core.data.lists import ExportablePPList, PPList
 from ansys.simai.core.data.post_processings import (
     GlobalCoefficients,
-    PPSurfaceLocation,
     Slice,
     SurfaceEvol,
-    SurfacePpOutputs,
+    SurfaceVTP,
+    SurfaceVTPTDLocation,
     VolumeVTU,
 )
 
@@ -145,15 +145,12 @@ class SelectionPostProcessingsMethods:
         """
         return PPList(selection=self._selection, post=lambda pred: pred.post.volume_vtu())
 
-    def surface_vtp(
-        self, pp_location: PPSurfaceLocation = PPSurfaceLocation.ON_CELLS
-    ) -> PPList[SurfacePpOutputs]:
+    def surface_vtp(self) -> PPList[SurfaceVTP]:
         """Compute or get the result of each prediction's surface in the VTP format.
 
         This is a non-blocking method. It returns a
         :py:class:`~ansys.simai.core.data.lists.PPList` instance of
-        :py:class:`~ansys.simai.core.data.post_processings.PostProcessingOnCells` or
-        :py:class:`~ansys.simai.core.data.post_processings.PostProcessingAsLearnt`,
+        :py:class:`~ansys.simai.core.data.post_processings.SurfaceVTP`
         objects without waiting. Those ``PostProcessing`` objects may not have
         data right away if the computation is still in progress. Data is filled
         asynchronously once the computation is finished.
@@ -163,17 +160,33 @@ class SelectionPostProcessingsMethods:
         The computation is launched only on first call of this method.
         Subsequent calls do not relaunch it.
 
-        Args:
-            pp_location: the post-processing data location. It can be one of
-                :class:`~ansys.simai.core.data.post_processings.PPSurfaceLocation`,
-                otherwise an InvalidArgument error is raised.
-                Default is PPSurfaceLocation.ON_CELLS.
+        Returns:
+            :py:class:`~ansys.simai.core.data.lists.PPList` instance of
+            :py:class:`~ansys.simai.core.data.post_processings.SurfaceVTP` objects.
+        """
+        return PPList(selection=self._selection, post=lambda pred: pred.post.surface_vtp())
+
+    def surface_vtp_td_location(self) -> PPList[SurfaceVTPTDLocation]:
+        """Compute or get the result of each prediction's surface in the VTP format.
+
+        This method keeps the original data association as they are in the sample.
+
+        It is a non-blocking method. It returns a
+        :py:class:`~ansys.simai.core.data.lists.PPList` instance of
+        :py:class:`~ansys.simai.core.data.post_processings.SurfaceVTPTDLocation`,
+        objects without waiting. Those ``PostProcessing`` objects may not have
+        data right away if the computation is still in progress. Data is filled
+        asynchronously once the computation is finished.
+        The state of computation can be waited upon with the ``wait()`` method.
+
+
+        The computation is launched only on first call of this method.
+        Subsequent calls do not relaunch it.
 
         Returns:
             :py:class:`~ansys.simai.core.data.lists.PPList` instance of
-            :py:class:`~ansys.simai.core.data.post_processings.PostProcessingOnCells` or
-            :py:class:`~ansys.simai.core.data.post_processings.PostProcessingAsLearnt` objects.
+            :py:class:`~ansys.simai.core.data.post_processings.SurfaceVTPTDLocation`
         """
         return PPList(
-            selection=self._selection, post=lambda pred: pred.post.surface_vtp(True, pp_location)
+            selection=self._selection, post=lambda pred: pred.post.surface_vtp_td_location()
         )

--- a/src/ansys/simai/core/data/selection_post_processings.py
+++ b/src/ansys/simai/core/data/selection_post_processings.py
@@ -28,8 +28,8 @@ from ansys.simai.core.data.post_processings import (
     PPSurfaceLocation,
     Slice,
     SurfaceEvol,
-    SurfaceVTP,
     VolumeVTU,
+    _SurfaceVTP,
 )
 
 if TYPE_CHECKING:
@@ -147,12 +147,13 @@ class SelectionPostProcessingsMethods:
 
     def surface_vtp(
         self, pp_location: PPSurfaceLocation = PPSurfaceLocation.ON_CELLS
-    ) -> PPList[SurfaceVTP]:
+    ) -> PPList[_SurfaceVTP]:
         """Compute or get the result of each prediction's surface in the VTP format.
 
         This is a non-blocking method. It returns a
         :py:class:`~ansys.simai.core.data.lists.PPList` instance of
-        :py:class:`~ansys.simai.core.data.post_processings.SurfaceVTP`
+        :py:class:`~ansys.simai.core.data.post_processings.PostProcessingOnCells` or
+        :py:class:`~ansys.simai.core.data.post_processings.PostProcessingAsLearnt`,
         objects without waiting. Those ``PostProcessing`` objects may not have
         data right away if the computation is still in progress. Data is filled
         asynchronously once the computation is finished.
@@ -170,7 +171,8 @@ class SelectionPostProcessingsMethods:
 
         Returns:
             :py:class:`~ansys.simai.core.data.lists.PPList` instance of
-            :py:class:`~ansys.simai.core.data.post_processings.SurfaceVTP` objects.
+            :py:class:`~ansys.simai.core.data.post_processings.PostProcessingOnCells` or
+            :py:class:`~ansys.simai.core.data.post_processings.PostProcessingAsLearnt` objects.
         """
         return PPList(
             selection=self._selection, post=lambda pred: pred.post.surface_vtp(True, pp_location)

--- a/src/ansys/simai/core/data/selection_post_processings.py
+++ b/src/ansys/simai/core/data/selection_post_processings.py
@@ -25,10 +25,10 @@ from typing import TYPE_CHECKING
 from ansys.simai.core.data.lists import ExportablePPList, PPList
 from ansys.simai.core.data.post_processings import (
     GlobalCoefficients,
+    PPSurfaceLocation,
     Slice,
     SurfaceEvol,
     SurfaceVTP,
-    SurfaceVTPTDLocation,
     VolumeVTU,
 )
 
@@ -145,7 +145,9 @@ class SelectionPostProcessingsMethods:
         """
         return PPList(selection=self._selection, post=lambda pred: pred.post.volume_vtu())
 
-    def surface_vtp(self) -> PPList[SurfaceVTP]:
+    def surface_vtp(
+        self, pp_location: PPSurfaceLocation = PPSurfaceLocation.ON_CELLS
+    ) -> PPList[SurfaceVTP]:
         """Compute or get the result of each prediction's surface in the VTP format.
 
         This is a non-blocking method. It returns a
@@ -160,29 +162,16 @@ class SelectionPostProcessingsMethods:
         The computation is launched only on first call of this method.
         Subsequent calls do not relaunch it.
 
-        Returns:
-            :py:class:`~ansys.simai.core.data.lists.PPList` instance of
-            :py:class:`~ansys.simai.core.data.post_processings.SurfaceVTP` objects.
-        """
-        return PPList(selection=self._selection, post=lambda pred: pred.post.surface_vtp())
-
-    def predict_as_learnt(self) -> PPList[SurfaceVTPTDLocation]:
-        """Compute or get the result of each prediction's surface in the VTP format.
-
-        This is a non-blocking method. It returns a
-        :py:class:`~ansys.simai.core.data.lists.PPList` instance of
-        :py:class:`~ansys.simai.core.data.post_processings.SurfaceVTP`
-        objects without waiting. Those ``PostProcessing`` objects may not have
-        data right away if the computation is still in progress. Data is filled
-        asynchronously once the computation is finished.
-        The state of computation can be waited upon with the ``wait()`` method.
-
-
-        The computation is launched only on first call of this method.
-        Subsequent calls do not relaunch it.
+        Args:
+            pp_location: the post-processing data location. It can be one of
+                :class:`~ansys.simai.core.data.post_processings.PPSurfaceLocation`,
+                otherwise an InvalidArgument error is raised.
+                Default is PPSurfaceLocation.ON_CELLS.
 
         Returns:
             :py:class:`~ansys.simai.core.data.lists.PPList` instance of
             :py:class:`~ansys.simai.core.data.post_processings.SurfaceVTP` objects.
         """
-        return PPList(selection=self._selection, post=lambda pred: pred.post.predict_as_learnt())
+        return PPList(
+            selection=self._selection, post=lambda pred: pred.post.surface_vtp(True, pp_location)
+        )

--- a/src/ansys/simai/core/data/selection_post_processings.py
+++ b/src/ansys/simai/core/data/selection_post_processings.py
@@ -28,6 +28,7 @@ from ansys.simai.core.data.post_processings import (
     Slice,
     SurfaceEvol,
     SurfaceVTP,
+    SurfaceVTPTDLocation,
     VolumeVTU,
 )
 
@@ -164,3 +165,24 @@ class SelectionPostProcessingsMethods:
             :py:class:`~ansys.simai.core.data.post_processings.SurfaceVTP` objects.
         """
         return PPList(selection=self._selection, post=lambda pred: pred.post.surface_vtp())
+
+    def predict_as_learnt(self) -> PPList[SurfaceVTPTDLocation]:
+        """Compute or get the result of each prediction's surface in the VTP format.
+
+        This is a non-blocking method. It returns a
+        :py:class:`~ansys.simai.core.data.lists.PPList` instance of
+        :py:class:`~ansys.simai.core.data.post_processings.SurfaceVTP`
+        objects without waiting. Those ``PostProcessing`` objects may not have
+        data right away if the computation is still in progress. Data is filled
+        asynchronously once the computation is finished.
+        The state of computation can be waited upon with the ``wait()`` method.
+
+
+        The computation is launched only on first call of this method.
+        Subsequent calls do not relaunch it.
+
+        Returns:
+            :py:class:`~ansys.simai.core.data.lists.PPList` instance of
+            :py:class:`~ansys.simai.core.data.post_processings.SurfaceVTP` objects.
+        """
+        return PPList(selection=self._selection, post=lambda pred: pred.post.predict_as_learnt())

--- a/tests/test_post_processings_results.py
+++ b/tests/test_post_processings_results.py
@@ -35,8 +35,8 @@ from ansys.simai.core.data.post_processings import (
     PPSurfaceLocation,
     Slice,
     SurfaceEvol,
-    SurfaceVTP,
     VolumeVTU,
+    _SurfaceVTP,
 )
 from ansys.simai.core.errors import InvalidArguments
 
@@ -337,7 +337,7 @@ def test_post_processing_result_surface_vtp(simai_client):
 
     pred = simai_client._prediction_directory._model_from({"id": "7546", "state": "successful"})
     surface_vtp = pred.post.surface_vtp()
-    assert isinstance(surface_vtp, SurfaceVTP)
+    assert isinstance(surface_vtp, _SurfaceVTP)
     assert isinstance(surface_vtp.data, DownloadableResult)
     # Test a binary download
     binary_io = surface_vtp.data.in_memory()
@@ -404,7 +404,7 @@ def test_error_in_wrong_location_in_post_processing_surface_vtp(simai_client):
 
     pred = simai_client._prediction_directory._model_from({"id": "7546", "state": "successful"})
 
-    class TestClass(SurfaceVTP):
+    class TestClass(_SurfaceVTP):
         pass
 
     with pytest.raises(InvalidArguments) as ex:

--- a/tests/test_post_processings_results.py
+++ b/tests/test_post_processings_results.py
@@ -23,17 +23,22 @@
 import json
 from io import BytesIO
 
+import pytest
 import responses
 
 from ansys.simai.core.data.post_processings import (
     CustomVolumePointCloud,
     DownloadableResult,
     GlobalCoefficients,
+    PostProcessingAsLearnt,
+    PostProcessingOnCells,
+    PPSurfaceLocation,
     Slice,
     SurfaceEvol,
     SurfaceVTP,
     VolumeVTU,
 )
+from ansys.simai.core.errors import InvalidArguments
 
 
 @responses.activate
@@ -342,6 +347,77 @@ def test_post_processing_result_surface_vtp(simai_client):
 
     # we have used vtp.data twice, generating 2 hits to the endpoint
     assert responses.assert_call_count("https://test.test/post-processings/01010101654", 2)
+
+
+@responses.activate
+def test_post_processing_result_surface_vtp_predict_as_learnt(simai_client):
+    """WHEN Running a surface_vtp post-processing on a prediction
+    WITH predict-as-learnt option (location is PPSurfaceLocation.AS_LEARNT)
+    AND calling its .data field,
+    THEN a GET request is made on the post-processings/SurfaceVTPTDLocation endpoint
+    AND the returned instance is of type PostProcessingAsLearnt.
+    """
+    # Mock request for PP creation
+    responses.add(
+        responses.POST,
+        "https://test.test/predictions/7546/post-processings/SurfaceVTPTDLocation",
+        json={"id": "01010101654", "state": "successful"},
+        status=200,
+    )
+
+    pred = simai_client._prediction_directory._model_from({"id": "7546", "state": "successful"})
+    surface_vtp = pred.post.surface_vtp(pp_location=PPSurfaceLocation.AS_LEARNT)
+    assert responses.assert_call_count(
+        "https://test.test/predictions/7546/post-processings/SurfaceVTPTDLocation", 1
+    )
+    assert isinstance(surface_vtp, PostProcessingAsLearnt)
+
+
+@responses.activate
+def test_post_processing_result_surface_vtp_predict_on_cells(simai_client):
+    """WHEN Running a surface_vtp post-processing on a prediction
+    WITH predict-on-cells option (location is PPSurfaceLocation.ON_CELLS)
+    THEN a GET request is made on the post-processings/SurfaceVTP endpoint
+    AND the returned instance is of type PostProcessingOnCells.
+    """
+    # Mock request for PP creation
+    responses.add(
+        responses.POST,
+        "https://test.test/predictions/7546/post-processings/SurfaceVTP",
+        json={"id": "01010101654", "state": "successful"},
+        status=200,
+    )
+
+    pred = simai_client._prediction_directory._model_from({"id": "7546", "state": "successful"})
+    surface_vtp = pred.post.surface_vtp(pp_location=PPSurfaceLocation.ON_CELLS)
+    assert responses.assert_call_count(
+        "https://test.test/predictions/7546/post-processings/SurfaceVTP", 1
+    )
+    assert isinstance(surface_vtp, PostProcessingOnCells)
+
+
+def test_error_in_wrong_location_in_post_processing_surface_vtp(simai_client):
+    """WHEN Running a surface_vtp post-processing on a prediction
+    WITH wrong pp_location,
+    THEN an InvalidArguments error is raised.
+    """
+
+    pred = simai_client._prediction_directory._model_from({"id": "7546", "state": "successful"})
+
+    class TestClass(SurfaceVTP):
+        pass
+
+    with pytest.raises(InvalidArguments) as ex:
+        _ = pred.post.surface_vtp(pp_location=TestClass)
+        assert list(PPSurfaceLocation) in ex.value
+
+    with pytest.raises(InvalidArguments) as ex:
+        _ = pred.post.surface_vtp(pp_location="a_string")
+        assert list(PPSurfaceLocation) in ex.value
+
+    with pytest.raises(InvalidArguments) as ex:
+        _ = pred.post.surface_vtp(pp_location=str)
+        assert list(PPSurfaceLocation) in ex.value
 
 
 @responses.activate

--- a/tests/test_selection_post_processings.py
+++ b/tests/test_selection_post_processings.py
@@ -25,12 +25,11 @@ import responses
 
 from ansys.simai.core.data.post_processings import (
     GlobalCoefficients,
-    PostProcessingAsLearnt,
-    PPSurfaceLocation,
     Slice,
     SurfaceEvol,
+    SurfaceVTP,
+    SurfaceVTPTDLocation,
     VolumeVTU,
-    _SurfaceVTP,
 )
 from ansys.simai.core.data.selection_post_processings import ExportablePPList, PPList
 from ansys.simai.core.data.selections import Selection
@@ -180,14 +179,14 @@ def test_selection_post_processing_surface_vtp(test_selection):
     assert isinstance(post_processings, PPList)
     assert len(post_processings) == 2
     for pp in post_processings:
-        assert isinstance(pp, _SurfaceVTP)
+        assert isinstance(pp, SurfaceVTP)
 
 
 @responses.activate
-def test_selection_post_processing_surface_vtp_predict_as_learnt(test_selection):
+def test_selection_post_processing_surface_vtp_td_location(test_selection):
     """WHEN I call post.post.surface_vtp() on a selection
     THEN the /SurfaceVTPTDLocation endpoint is called for each prediction in the selection
-    AND I get a list of PostProcessingVTUExport objects in return
+    AND I get a list of SurfaceVTPTDLocation objects in return
     """
     assert len(test_selection.points) == 2
 
@@ -203,11 +202,11 @@ def test_selection_post_processing_surface_vtp_predict_as_learnt(test_selection)
         json={"id": "vtu02", "status": "queued"},
         status=200,
     )
-    post_processings = test_selection.post.surface_vtp(pp_location=PPSurfaceLocation.AS_LEARNT)
+    post_processings = test_selection.post.surface_vtp_td_location()
     assert isinstance(post_processings, PPList)
     assert len(post_processings) == 2
     for pp in post_processings:
-        assert isinstance(pp, PostProcessingAsLearnt)
+        assert isinstance(pp, SurfaceVTPTDLocation)
 
 
 @responses.activate

--- a/tests/test_selection_post_processings.py
+++ b/tests/test_selection_post_processings.py
@@ -29,8 +29,8 @@ from ansys.simai.core.data.post_processings import (
     PPSurfaceLocation,
     Slice,
     SurfaceEvol,
-    SurfaceVTP,
     VolumeVTU,
+    _SurfaceVTP,
 )
 from ansys.simai.core.data.selection_post_processings import ExportablePPList, PPList
 from ansys.simai.core.data.selections import Selection
@@ -180,7 +180,7 @@ def test_selection_post_processing_surface_vtp(test_selection):
     assert isinstance(post_processings, PPList)
     assert len(post_processings) == 2
     for pp in post_processings:
-        assert isinstance(pp, SurfaceVTP)
+        assert isinstance(pp, _SurfaceVTP)
 
 
 @responses.activate

--- a/tests/test_selection_post_processings.py
+++ b/tests/test_selection_post_processings.py
@@ -25,6 +25,8 @@ import responses
 
 from ansys.simai.core.data.post_processings import (
     GlobalCoefficients,
+    PostProcessingAsLearnt,
+    PPSurfaceLocation,
     Slice,
     SurfaceEvol,
     SurfaceVTP,
@@ -179,6 +181,33 @@ def test_selection_post_processing_surface_vtp(test_selection):
     assert len(post_processings) == 2
     for pp in post_processings:
         assert isinstance(pp, SurfaceVTP)
+
+
+@responses.activate
+def test_selection_post_processing_surface_vtp_predict_as_learnt(test_selection):
+    """WHEN I call post.post.surface_vtp() on a selection
+    THEN the /SurfaceVTPTDLocation endpoint is called for each prediction in the selection
+    AND I get a list of PostProcessingVTUExport objects in return
+    """
+    assert len(test_selection.points) == 2
+
+    responses.add(
+        responses.POST,
+        "https://test.test/predictions/pred1/post-processings/SurfaceVTPTDLocation",
+        json={"id": "vtu01", "status": "queued"},
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://test.test/predictions/pred2/post-processings/SurfaceVTPTDLocation",
+        json={"id": "vtu02", "status": "queued"},
+        status=200,
+    )
+    post_processings = test_selection.post.surface_vtp(pp_location=PPSurfaceLocation.AS_LEARNT)
+    assert isinstance(post_processings, PPList)
+    assert len(post_processings) == 2
+    for pp in post_processings:
+        assert isinstance(pp, PostProcessingAsLearnt)
 
 
 @responses.activate


### PR DESCRIPTION
## Description

This PR enables users to trigger post-processing on surface variables letting the original data association of the sample; e.g., data associated with points will continue be associated with points. 

To enable this option, the class `SurfaceVTPTDLocation` is introduced, together with the methods `PredictionPostProcessings.surface_vtp_td_location` and `SelectionPostProcessingsMethods.surface_vtp_td_location`. These methods trigger a post-processing on the surface variables while keeping the original data association.

Story: [sc-26496]

## Tests
- Unit-tests added
- Interactive smoke testing against dev env.