### PR TITLE
rm yias fom codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*               @ansys/pysimai-maintainers @yias
+*               @ansys/pysimai-maintainers


### PR DESCRIPTION
@yias I don't think you're the pysimai person anymore, with this change `pysimai-maintainers` will be sole CODEOWNER.

Feel free to merge / close / ..., I'm not supposed to choose who works on what