### PR TITLE
fix: CI documentation build

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: "3.10"
+  MAIN_PYTHON_VERSION: "3.12"
   DOCUMENTATION_CNAME: "simai.docs.pyansys.com"
   LIBRARY_NAME: "ansys-simai-core"
 
@@ -88,6 +88,8 @@ jobs:
     steps:
       - name: Setup PDM
         uses: pdm-project/setup-pdm@v4
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
       - uses: actions/checkout@v4
       - name: Generate doc requirements
         run: pdm export -G doc --no-default -o doc_requirements.txt

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -48,6 +48,9 @@ jobs:
           library-name: ${{ env.LIBRARY_NAME }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
+          # jeepney is MIT but action thinks it's UNKNOWN
+          # https://gitlab.com/takluyver/jeepney/-/blob/master/LICENSE?ref_type=heads
+          whitelist-license-check: "jeepney"
 
   tests:
     name: "Test using Python ${{ matrix.python-version }}"


### PR DESCRIPTION
pdm action would install python 3.13 which would then be used later despite requiring python 3.10 in the doc building action. Sphinx currently requires <= Python3.12 to build correctly when using Pathlib Alternatively the latest release of sphinx fixes it but there's some dependency resolution issue since we still support Python3.9 so we can't switch yet.