### PR TITLE
reduce sleep() time in auth unit tests

### DIFF
--- a/src/ansys/simai/core/utils/auth.py
+++ b/src/ansys/simai/core/utils/auth.py
@@ -44,6 +44,9 @@ from ansys.simai.core.utils.requests import handle_response
 
 logger = logging.getLogger(__name__)
 
+# polling can't be faster or auth server returns HTTP 400 Slow down
+DEVICE_AUTH_POLLING_INTERVAL = 5
+
 
 class _AuthTokens(BaseModel):
     """Represents the OIDC tokens received from the auth server."""
@@ -141,8 +144,7 @@ class _AuthTokensRetriever:
         webbrowser.open(auth_codes["verification_uri_complete"])
         # loop will exit when auth server returns "400 Device code is expired"
         while True:
-            # polling can't be faster or auth server returns HTTP 400 Slow down
-            time.sleep(5)
+            time.sleep(DEVICE_AUTH_POLLING_INTERVAL)
             validation = self.session.post(
                 self.token_url,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},

--- a/tests/utils/test_auth.py
+++ b/tests/utils/test_auth.py
@@ -170,6 +170,7 @@ def test_request_auth_tokens_device_grant_with_bad_cache(mocker, tmpdir):
     """
     webbrowser_open = mocker.patch("webbrowser.open")
     mocker.patch("ansys.simai.core.utils.auth.get_cache_dir", return_value=tmpdir)
+    mocker.patch("ansys.simai.core.utils.auth.DEVICE_AUTH_POLLING_INTERVAL", 0)
     refresh_token = "spaghetti"
     device_code = "foxtrot uniform charlie kilo"
     realm_url = "http://myauthserver.com/my-realm"
@@ -388,7 +389,10 @@ def test_authenticator_automatically_refreshes_auth_before_refresh_token_expires
     )
     assert resps_direct_grant.call_count == 1
     assert resps_refresh.call_count == 0
-    time.sleep(2)
+    t0 = time.time()
+    while time.time() - t0 < 2 and resps_refresh.call_count == 0:
+        # wait for the daemon thread to do its thing, of for the 2sec timeout...
+        time.sleep(0.1)
     # Tokens are automatically refreshed so refresh token doesn't expire'
     assert resps_direct_grant.call_count == 1
     assert resps_refresh.call_count == 1

--- a/tests/utils/test_auth.py
+++ b/tests/utils/test_auth.py
@@ -391,7 +391,7 @@ def test_authenticator_automatically_refreshes_auth_before_refresh_token_expires
     assert resps_refresh.call_count == 0
     t0 = time.time()
     while time.time() - t0 < 2 and resps_refresh.call_count == 0:
-        # wait for the daemon thread to do its thing, of for the 2sec timeout...
+        # wait for the daemon thread to do its thing, or for the 2sec timeout...
         time.sleep(0.1)
     # Tokens are automatically refreshed so refresh token doesn't expire'
     assert resps_direct_grant.call_count == 1


### PR DESCRIPTION
This removes a 5s sleep and replaces a 2s sleep by a poll every ~100ms in unit tests