### PR TITLE
feat: add checks on "build on top"

### DIFF
--- a/doc/source/api_reference/projects.rst
+++ b/doc/source/api_reference/projects.rst
@@ -26,3 +26,15 @@ IsTrainableInfo
 .. autoclass:: IsTrainableInfo()
     :members:
     :exclude-members: is_trainable, reason
+
+TrainingCapabilities
+--------------------
+
+.. autoclass:: TrainingCapabilities()
+    :members:
+
+ContinuousLearningCapabilities
+------------------------------
+
+.. autoclass:: ContinuousLearningCapabilities()
+    :members:

--- a/src/ansys/simai/core/api/project.py
+++ b/src/ansys/simai/core/api/project.py
@@ -95,7 +95,7 @@ class ProjectClientMixin(ApiClientMixin):
         dismiss_data_with_fields_discrepancies: bool = False,
         dismiss_data_with_volume_overflow: bool = False,
     ):
-        """Launches a build on top of previous model for a project.
+        """Launches a build on top of the previous model for a project.
 
         Args:
             project_id: the ID of the project

--- a/src/ansys/simai/core/api/project.py
+++ b/src/ansys/simai/core/api/project.py
@@ -89,6 +89,26 @@ class ProjectClientMixin(ApiClientMixin):
         }
         return self._post(f"projects/{project_id}/model", json=config, params=params)
 
+    def launch_build_on_top(
+        self,
+        project_id: str,
+        dismiss_data_with_fields_discrepancies: bool = False,
+        dismiss_data_with_volume_overflow: bool = False,
+    ):
+        """Launches a build on top of previous model for a project.
+
+        Args:
+            project_id: the ID of the project
+            dismiss_data_with_fields_discrepancies: set to True for omitting data with missing properties
+            dismiss_data_with_volume_overflow: set to True for omitting data outside the Domain of Analysis
+
+        """
+        params = {
+            "dismiss_data_with_fields_discrepancies": dismiss_data_with_fields_discrepancies,
+            "dismiss_data_with_volume_overflow": dismiss_data_with_volume_overflow,
+        }
+        return self._post(f"projects/{project_id}/model/on-top", params=params)
+
     def is_project_trainable(self, project_id: str):
         return self._get(f"projects/{project_id}/trainable")
 

--- a/src/ansys/simai/core/data/models.py
+++ b/src/ansys/simai/core/data/models.py
@@ -107,6 +107,23 @@ class ModelDirectory(Directory[Model]):
         if not is_trainable:
             raise InvalidArguments(f"Cannot train model because: {is_trainable.reason}")
 
+        # Check if there is a difference between the two model configuration (except continuous field)
+        configuration_mismatch = not configuration.project.last_model_configuration or {
+            k
+            for k, _ in configuration.project.last_model_configuration._to_payload().items()
+            ^ configuration._to_payload().items()
+        } != {"continuous"}
+        if configuration.build_on_top and (
+            configuration_mismatch
+            or not configuration.project.training_capabilities.continuous_learning.able
+        ):
+            reasons = configuration.project.training_capabilities.continuous_learning.reasons
+            if configuration_mismatch:
+                reasons.append(
+                    "When using build on top, model configuration cannot change from last model configuration"
+                )
+            raise InvalidArguments(f"Cannot train model because: {reasons}")
+
         return self._model_from(
             self._client._api.launch_build(
                 configuration.project.id,

--- a/src/ansys/simai/core/data/models.py
+++ b/src/ansys/simai/core/data/models.py
@@ -108,19 +108,16 @@ class ModelDirectory(Directory[Model]):
             raise InvalidArguments(f"Cannot train model because: {is_trainable.reason}")
 
         if configuration.build_on_top:
-            return self._model_from(
-                self._client._api.launch_build_on_top(
-                    configuration.project.id,
-                    dismiss_data_with_fields_discrepancies,
-                    dismiss_data_with_volume_overflow,
-                )
+            response = self._client._api.launch_build_on_top(
+                configuration.project.id,
+                dismiss_data_with_fields_discrepancies,
+                dismiss_data_with_volume_overflow,
             )
         else:
-            return self._model_from(
-                self._client._api.launch_build(
-                    configuration.project.id,
-                    configuration._to_payload(),
-                    dismiss_data_with_fields_discrepancies,
-                    dismiss_data_with_volume_overflow,
-                )
+            response = self._client._api.launch_build(
+                configuration.project.id,
+                configuration._to_payload(),
+                dismiss_data_with_fields_discrepancies,
+                dismiss_data_with_volume_overflow,
             )
+        return self._model_from(response)


### PR DESCRIPTION
Currently, no check is done when building a model with continuous learning feature.
This PR add checks for model configuration changes and for the continuous learning capabilities returned from API.