### PR TITLE
feat: user api wont return record for jobs with pending status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 
 # vscode
 .vscode/
+
+# pycharm
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,3 +176,6 @@ source = ["ansys.simai.core"]
 [tool.coverage.report]
 show_missing = true
 exclude_also = ["if TYPE_CHECKING:"]
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"

--- a/src/ansys/simai/core/data/base.py
+++ b/src/ansys/simai/core/data/base.py
@@ -42,6 +42,7 @@ PENDING_STATES = [
     "requested",
     "processing",
     "pending_retry",
+    "stalled",
 ]
 
 
@@ -211,19 +212,24 @@ class ComputableDataModel(DataModel):
     def _handle_job_sse_event(self, data):
         """Update object with the information and state received through the SSE."""
         logger.debug(f"Handling SSE job event for {self._classname} id {self.id}")
-        self.fields = data["record"]
-        state: str = data["record"]["state"]
+
+        state: str = data["status"]
+
         if state in PENDING_STATES:
             logger.debug(f"{self._classname} id {self.id} set status pending")
             self._set_is_pending()
-        elif state == "successful":
-            logger.debug(f"{self._classname} id {self.id} set status successful")
-            self._set_is_over()
-        elif state in ERROR_STATES:
-            reason_str = f"with reason {self.fields.get('error')}"
-            logger.debug(f"{self._classname} id {self.id} set status failed {reason_str}")
-            self._set_has_failed()
-            logger.error(self.fields.get("error"))
+        else:
+            # Only update fields if state is not in PENDING_STATES
+            self.fields = data["record"]
+
+            if state == "successful":
+                logger.debug(f"{self._classname} id {self.id} set status successful")
+                self._set_is_over()
+            elif state in ERROR_STATES:
+                reason_str = f"with reason {self.fields.get('error')}"
+                logger.debug(f"{self._classname} id {self.id} set status failed {reason_str}")
+                self._set_has_failed()
+                logger.error(self.fields.get("error"))
 
 
 DataModelType = TypeVar("DataModelType", bound=DataModel)

--- a/src/ansys/simai/core/data/base.py
+++ b/src/ansys/simai/core/data/base.py
@@ -220,7 +220,8 @@ class ComputableDataModel(DataModel):
             self._set_is_pending()
         else:
             # Only update fields if state is not in PENDING_STATES
-            self.fields = data["record"]
+            if record := data.get("record"):
+                self.fields = record
 
             if state == "successful":
                 logger.debug(f"{self._classname} id {self.id} set status successful")

--- a/tests/test_core_sse.py
+++ b/tests/test_core_sse.py
@@ -128,17 +128,17 @@ create_sse_event = NamedTuple("SSEEvent", [("data", dict)])
 
 
 def test_sse_event_prediction_success(sse_mixin, prediction_factory):
-    """WHEN SSEMixin receives a SSE message updating a prediction to success
+    """WHEN SSEMixin receives an SSE message updating a prediction to success
     THEN the appropriate prediction is updated and changes state to successful
     """
     pred = prediction_factory(state="processing")
     assert pred.is_pending
-    # Mock a SSE success event
+    # Mock an SSE success event
     updated_record = pred.fields.copy()
     updated_record.update({"state": "successful", "confidence_score": "high"})
     sse_mixin._handle_sse_event(
         create_sse_event(
-            f'{{"target": {{"id": "{pred.id}", "type": "prediction"}}, "type": "job", "record": {json.dumps(updated_record)}}}'
+            f'{{"target": {{"id": "{pred.id}", "type": "prediction"}}, "status": "successful", "type": "job", "record": {json.dumps(updated_record)}}}'
         )
     )
     assert not pred.is_pending
@@ -157,7 +157,7 @@ def test_sse_event_update_prediction_failure(sse_mixin, prediction_factory):
     updated_record.update({"state": "failure", "error": "something went wrong"})
     sse_mixin._handle_sse_event(
         create_sse_event(
-            f'{{"target": {{"id": "{pred.id}", "type": "prediction"}}, "type": "job", "record": {json.dumps(updated_record)}}}'
+            f'{{"target": {{"id": "{pred.id}", "type": "prediction"}}, "status": "failure", "type": "job", "record": {json.dumps(updated_record)}}}'
         )
     )
     assert not pred.is_pending
@@ -228,6 +228,7 @@ def test_prediction_data_update(simai_client, prediction_factory):
     simai_client._prediction_directory._handle_sse_event(
         {
             "reason": "",
+            "status": "successful",
             "result": {"data": {"values": {"confidence_score": "low"}}, "dim": 1},
             "target": {"id": pred.id, "type": "prediction"},
             "type": "job",


### PR DESCRIPTION
In upcoming versions, the user_api will no longer return record data updates for jobs in pending states, as these states don't contain meaningful changes. Additionally, job state information will be retrieved directly from the `status` field.