### PR TITLE
feat: optional boundary conditions on optimization runs

### DIFF
--- a/src/ansys/simai/core/data/optimizations.py
+++ b/src/ansys/simai/core/data/optimizations.py
@@ -22,7 +22,7 @@
 
 import logging
 from inspect import signature
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
+from typing import Callable, Dict, List, Literal, Optional, Tuple
 
 from tqdm import tqdm
 from wakepy import keep
@@ -181,11 +181,6 @@ class OptimizationDirectory(Directory[Optimization]):
         _validate_geometry_parameters(geometry_parameters)
         _validate_geometry_generation_fn_signature(geometry_generation_fn, geometry_parameters)
         _validate_outcome_constraints(outcome_constraints)
-
-        model_bc = get_object_from_identifiable(
-            workspace, self._client._workspace_directory, self._client._current_workspace
-        ).model_manifest.boundary_conditions
-        _validate_boundary_conditions_keys(boundary_conditions, model_bc)
         objective = _build_objective(minimize, maximize)
         optimization_parameters = {
             "boundary_conditions": boundary_conditions or {},
@@ -299,11 +294,6 @@ class OptimizationDirectory(Directory[Optimization]):
         _validate_n_iters(n_iters)
         _validate_global_coefficients_for_non_parametric(minimize, maximize)
         _validate_bounding_boxes(bounding_boxes)
-
-        workspace = self._client._workspace_directory.get(id=geometry._fields["workspace_id"])
-        _validate_boundary_conditions_keys(
-            boundary_conditions, workspace.model_manifest.boundary_conditions
-        )
         geometry = get_object_from_identifiable(geometry, self._client._geometry_directory)
         objective = _build_objective(minimize, maximize)
         optimization_parameters = {
@@ -458,27 +448,6 @@ def _validate_n_iters(n_iters) -> None:
 
     if n_iters <= 0:
         raise InvalidArguments("n_iters must be strictly positive")
-
-
-def _validate_boundary_conditions_keys(
-    input_bc: Optional[Dict[str, float]], model_bc: Dict[str, Any]
-) -> None:
-    """Validate boundary conditions keys against workspace model requirements."""
-    required_bc = set(model_bc.keys())
-
-    if not required_bc:
-        return
-
-    if input_bc is None:
-        raise InvalidArguments(
-            f"Model requires boundary conditions {sorted(required_bc)} but None was provided"
-        )
-
-    provided_bc = set(input_bc.keys())
-    missing_bc = required_bc - provided_bc
-
-    if missing_bc:
-        raise InvalidArguments(f"Missing required boundary conditions {sorted(missing_bc)}")
 
 
 def _build_objective(minimize: list[str], maximize: list[str]) -> dict:

--- a/src/ansys/simai/core/data/optimizations.py
+++ b/src/ansys/simai/core/data/optimizations.py
@@ -461,10 +461,10 @@ def _validate_n_iters(n_iters) -> None:
 
 
 def _validate_boundary_conditions_keys(
-    input_bc: Dict[str, float] | None, model_bc: Dict[str, Any]
+    input_bc: Optional[Dict[str, float]], model_bc: Dict[str, Any]
 ) -> None:
     """Validate boundary conditions keys against workspace model requirements."""
-    required_bc = set(model_bc.keys()) if model_bc else set()
+    required_bc = set(model_bc.keys())
 
     if not required_bc:
         return

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -230,6 +230,9 @@ def test_validate_boundary_conditions_keys_success():
 
     _validate_boundary_conditions_keys(input_bc, model_bc)
 
+    # If the model doesn't require boundary conditions
+    _validate_boundary_conditions_keys(input_bc, {})
+
 
 @pytest.mark.parametrize(
     "input_bc, model_bc, error_message",

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -22,7 +22,6 @@
 # ruff: noqa: E731
 
 import json
-import re
 import threading
 
 import pytest
@@ -30,7 +29,6 @@ import responses
 import sseclient
 
 from ansys.simai.core.data.optimizations import (
-    _validate_boundary_conditions_keys,
     _validate_bounding_boxes,
     _validate_geometry_generation_fn_signature,
     _validate_global_coefficients_for_non_parametric,
@@ -224,44 +222,6 @@ def test_validate_n_iters_fails(n_iters, error_message):
         _validate_n_iters(n_iters)
 
 
-def test_validate_boundary_conditions_keys_success():
-    input_bc = {"Vx": 5.1, "Vy": 10.1}
-    model_bc = {"Vy": {"something": []}, "Vx": {"something": []}}
-
-    _validate_boundary_conditions_keys(input_bc, model_bc)
-
-    # If the model doesn't require boundary conditions
-    _validate_boundary_conditions_keys(input_bc, {})
-
-
-@pytest.mark.parametrize(
-    "input_bc, model_bc, error_message",
-    [
-        (
-            None,
-            {"Vx": {"something": []}},
-            "Model requires boundary conditions ['Vx'] but None was provided",
-        ),
-        (
-            {"WrongWrong": 5},
-            {"Vx": {"something": []}},
-            "Missing required boundary conditions ['Vx']",
-        ),
-        (
-            {"Px": 5, "Vx": 5, "Lx": 5},
-            {"Vx": {"something": []}, "Vy": {"something": []}, "Vz": {"something": []}},
-            "Missing required boundary conditions ['Vy', 'Vz']",
-        ),
-    ],
-)
-def test_validate_boundary_conditions_keys_fails(input_bc, model_bc, error_message):
-    with pytest.raises(
-        expected_exception=InvalidArguments,
-        match=re.escape(error_message),
-    ):
-        _validate_boundary_conditions_keys(input_bc, model_bc)
-
-
 @responses.activate
 def test_run_parametric_optimization(simai_client, mocker):
     workspace_id = "insert_cool_reference"
@@ -269,18 +229,6 @@ def test_run_parametric_optimization(simai_client, mocker):
     geometry_upload = mocker.patch.object(simai_client.geometries, "upload")
     geometry_upload.return_value = simai_client.geometries._model_from({"id": "geomx"})
 
-    responses.add(
-        responses.GET,
-        f"https://test.test/workspaces/{workspace_id}",
-        status=202,
-        json={"id": workspace_id, "name": workspace_id},
-    )
-    responses.add(
-        responses.GET,
-        f"https://test.test/workspaces/{workspace_id}/model/manifest/public",
-        status=202,
-        json={"boundary_conditions": {"VelocityX": {"something": []}}},
-    )
     responses.add(
         responses.POST,
         f"https://test.test/workspaces/{workspace_id}/optimizations",
@@ -368,18 +316,6 @@ def test_run_non_parametric_optimization(simai_client, geometry_factory):
     workspace_id = "insert_cool_reference"
     geometry = geometry_factory(workspace_id=workspace_id)
 
-    responses.add(
-        responses.GET,
-        f"https://test.test/workspaces/{workspace_id}",
-        status=202,
-        json={"id": workspace_id, "name": workspace_id},
-    )
-    responses.add(
-        responses.GET,
-        f"https://test.test/workspaces/{workspace_id}/model/manifest/public",
-        status=202,
-        json={"boundary_conditions": {"VelocityX": {"something": []}}},
-    )
     responses.add(
         responses.POST,
         f"https://test.test/workspaces/{workspace_id}/optimizations",


### PR DESCRIPTION
Set boundary conditions to optional on `simai.optimizations.run_non_parametric()` and `simai.optimizations.run_parametric()` ~and add checks to validate boundary conditions by raising an exception when required boundary conditions are missing.~