### PR TITLE
feat: add renaming methods

### DIFF
--- a/src/ansys/simai/core/api/geomai/workspaces.py
+++ b/src/ansys/simai/core/api/geomai/workspaces.py
@@ -91,3 +91,14 @@ class GeomAIWorkspaceClientMixin(ApiClientMixin):
         self, workspace_id: str, file: Optional[File]
     ):
         return self.download_file(f"geomai/workspaces/{workspace_id}/model-evaluation-report", file)
+
+    def update_geomai_workspace(self, workspace_id: str, name: str):
+        """Update a GeomAI workspace name.
+
+        Args:
+            workspace_id: ID of the workspace.
+            name: New name to give to the workspace.
+        """
+        request_json = {}
+        request_json["name"] = name
+        self._patch(f"geomai/workspaces/{workspace_id}", json=request_json, return_json=False)

--- a/src/ansys/simai/core/api/workspace.py
+++ b/src/ansys/simai/core/api/workspace.py
@@ -99,3 +99,14 @@ class WorkspaceClientMixin(ApiClientMixin):
 
     def download_workspace_mer_data(self, workspace_id: str, file: Optional[File]):
         return self.download_file(f"workspaces/{workspace_id}/mer-data", file)
+
+    def update_workspace(self, workspace_id: str, name: str):
+        """Update a workspace name.
+
+        Args:
+            workspace_id: ID of the workspace.
+            name: New name to give to the workspace.
+        """
+        request_json = {}
+        request_json["name"] = name
+        self._patch(f"workspaces/{workspace_id}", json=request_json, return_json=False)

--- a/src/ansys/simai/core/data/geomai/projects.py
+++ b/src/ansys/simai/core/data/geomai/projects.py
@@ -43,8 +43,7 @@ class GeomAIProject(DataModel):
         """Name of project."""
         return self.fields["name"]
 
-    @name.setter
-    def name(self, new_name: str):
+    def rename(self, new_name: str) -> None:
         """Rename the project.
 
         Args:

--- a/src/ansys/simai/core/data/geomai/workspaces.py
+++ b/src/ansys/simai/core/data/geomai/workspaces.py
@@ -45,6 +45,15 @@ class GeomAIWorkspace(DataModel):
         """Name of the workspace."""
         return self.fields["name"]
 
+    def rename(self, new_name: str) -> None:
+        """Rename the workspace.
+
+        Args:
+            new_name: New name to give to the workspace.
+        """
+        self._client._api.update_geomai_workspace(self.id, name=new_name)
+        self.reload()
+
     def delete(self):
         """Delete the workspace."""
         return self._client._api.delete_geomai_workspace(self.id)

--- a/src/ansys/simai/core/data/geometries.py
+++ b/src/ansys/simai/core/data/geometries.py
@@ -81,11 +81,11 @@ class Geometry(UploadableResourceMixin, ComputableDataModel):
         """The attached point cloud file information if any."""
         return self.fields.get("point_cloud")
 
-    def rename(self, name: str) -> None:
+    def rename(self, new_name: str) -> None:
         """Change the name of the geometry.
 
         Args:
-            name: New name to give to the geometry.
+            new_name: New name to give to the geometry.
 
         Note:
             Only the stem part is modified. The file extension is immutable.
@@ -93,7 +93,7 @@ class Geometry(UploadableResourceMixin, ComputableDataModel):
             If the new filename already contains dots other than for the extension,
             the extension must be provided.
         """
-        self._client._api.update_geometry(self.id, name=name)
+        self._client._api.update_geometry(self.id, name=new_name)
         self.reload()
 
     def update_metadata(self, metadata: Dict[str, Union[str, Number, bool]]):

--- a/src/ansys/simai/core/data/projects.py
+++ b/src/ansys/simai/core/data/projects.py
@@ -111,8 +111,7 @@ class Project(DataModel):
         """Name of project."""
         return self.fields["name"]
 
-    @name.setter
-    def name(self, new_name: str):
+    def rename(self, new_name: str) -> None:
         """Rename the project.
 
         Args:

--- a/src/ansys/simai/core/data/workspaces.py
+++ b/src/ansys/simai/core/data/workspaces.py
@@ -104,6 +104,15 @@ class Workspace(DataModel):
             )
         return self._model_manifest
 
+    def rename(self, new_name: str) -> None:
+        """Rename the workspace.
+
+        Args:
+            new_name: New name to give to the workspace.
+        """
+        self._client._api.update_workspace(self.id, name=new_name)
+        self.reload()
+
     def delete(self):
         """Delete the workspace."""
         return self._client._api.delete_workspace(self.id)

--- a/tests/geomai/test_geomai_projects.py
+++ b/tests/geomai/test_geomai_projects.py
@@ -32,7 +32,9 @@ if TYPE_CHECKING:
 
 
 def test_project_rename(simai_client, httpx_mock):
-    project = simai_client.geomai._project_directory._model_from({"id": "0011", "name": "riri"})
+    project: GeomAIProject = simai_client.geomai._project_directory._model_from(
+        {"id": "0011", "name": "riri"}
+    )
 
     httpx_mock.add_response(
         method="PATCH",
@@ -46,7 +48,7 @@ def test_project_rename(simai_client, httpx_mock):
         status_code=200,
     )
 
-    project.name = "fifi"
+    project.rename("fifi")
     assert project.name == "fifi"
 
 

--- a/tests/geomai/test_geomai_workspaces.py
+++ b/tests/geomai/test_geomai_workspaces.py
@@ -44,3 +44,24 @@ def test_geomai_workspace_download_mer(simai_client, httpx_mock):
     in_memory = workspace.download_model_evaluation_report()
     data_in_file = in_memory.readline()
     assert data_in_file.decode("ascii") == "mer-geomai"
+
+
+def test_geomai_workspace_rename(simai_client, httpx_mock):
+    workspace: GeomAIWorkspace = simai_client.geomai._workspace_directory._model_from(
+        {"id": "0011", "name": "riri"}
+    )
+
+    httpx_mock.add_response(
+        method="PATCH",
+        url="https://test.test/geomai/workspaces/0011",
+        status_code=204,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://test.test/geomai/workspaces/0011",
+        json={"id": "0011", "name": "fifi"},
+        status_code=200,
+    )
+
+    workspace.rename("fifi")
+    assert workspace.name == "fifi"

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -23,6 +23,10 @@
 import json
 import urllib.parse
 from io import BytesIO
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ansys.simai.core.data.geometries import Geometry
 
 
 def test_geometries_list_no_parameter(simai_client, httpx_mock):
@@ -151,3 +155,24 @@ def test_geometries_delete_point_cloud_cleares_pp_cache(
     assert custom_volume_point_cloud in prediction.post._local_post_processings
     geometry.delete_point_cloud()
     assert custom_volume_point_cloud not in prediction.post._local_post_processings
+
+
+def test_geometries_rename(simai_client, httpx_mock):
+    geometry: Geometry = simai_client._geometry_directory._model_from(
+        {"id": "0011", "name": "riri"}
+    )
+
+    httpx_mock.add_response(
+        method="PATCH",
+        url="https://test.test/geometries/0011",
+        status_code=204,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://test.test/geometries/0011",
+        json={"id": "0011", "name": "fifi"},
+        status_code=200,
+    )
+
+    geometry.rename("fifi")
+    assert geometry.name == "fifi"

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 
 def test_project_rename(simai_client, httpx_mock):
-    project = simai_client._project_directory._model_from({"id": "0011", "name": "riri"})
+    project: Project = simai_client._project_directory._model_from({"id": "0011", "name": "riri"})
 
     httpx_mock.add_response(
         method="PATCH",
@@ -47,7 +47,7 @@ def test_project_rename(simai_client, httpx_mock):
         status_code=200,
     )
 
-    project.name = "fifi"
+    project.rename("fifi")
     assert project.name == "fifi"
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -44,3 +44,24 @@ def test_workspace_download_mer_data(simai_client, httpx_mock):
     in_memory = workspace.download_mer_data()
     data_in_file = in_memory.readline()
     assert data_in_file.decode("ascii") == "mer-data-geometries"
+
+
+def test_workspace_rename(simai_client, httpx_mock):
+    workspace: Workspace = simai_client._workspace_directory._model_from(
+        {"id": "0011", "name": "riri"}
+    )
+
+    httpx_mock.add_response(
+        method="PATCH",
+        url="https://test.test/workspaces/0011",
+        status_code=204,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://test.test/workspaces/0011",
+        json={"id": "0011", "name": "fifi"},
+        status_code=200,
+    )
+
+    workspace.rename("fifi")
+    assert workspace.name == "fifi"


### PR DESCRIPTION
Add renaming methods to the following object :
- `Geometry`
- `Workspace`
- `GeomAIWorkspace`
- `Project`
- `GeomAIProject`

Removing `name` setter on `Project` and `GeomAIProject`

[sc-34253]