### PR TITLE
fix: add post-processing inputs in model configuration GC processing

### DIFF
--- a/src/ansys/simai/core/data/model_configuration.py
+++ b/src/ansys/simai/core/data/model_configuration.py
@@ -309,7 +309,7 @@ class ModelConfiguration:
             self.project.process_gc_formula(
                 gc_unit.formula,
                 self.input.boundary_conditions,
-                self.output.surface,
+                (self.output.surface or []) + (self.pp_input.surface or []),
                 gc_unit.gc_location,
             )
             verified_gcs.append(gc_unit)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -600,7 +600,7 @@ def test_post_process_input(mocker, simai_client, httpx_mock):
     build_model: Model = simai_client.models.build(config_with_pp_input)
 
     process_gc_formula.assert_called_once_with(
-        "max(Pressure)", ["Vx"], ["Pressure", "WallShearStress_0"], "cells"
+        "max(Pressure)", ["Vx"], ["Pressure", "WallShearStress_0", "TurbulentViscosity"], "cells"
     )
     assert config_with_pp_input.pp_input.surface == pp_input.surface
     assert (


### PR DESCRIPTION
When creating a model configuration, the function that process global coefficients doesn't take in account the post-processing surface inputs.

[sc-33295][sc-34746]