### PR TITLE
fix: add write permissions to deploy doc

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -147,6 +147,8 @@ jobs:
     needs: [build-library]
     timeout-minutes: 10
     if: github.event_name == 'push' && !contains(github.ref, 'refs/tags')
+    permissions:
+      contents: write
     steps:
       - uses: ansys/actions/doc-deploy-dev@21c9de9bee9692173780696d4a39964f20b9cfa3 # v10.1.5
         with:
@@ -161,6 +163,8 @@ jobs:
     needs: [build-library]
     timeout-minutes: 10
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    permissions:
+      contents: write
     steps:
       - uses: ansys/actions/doc-deploy-stable@21c9de9bee9692173780696d4a39964f20b9cfa3 # v10.1.5
         with:


### PR DESCRIPTION
Deploy doc jobs (dev / stable) need write permissions to push on branch