### PR TITLE
feat: add `model_configuration` property in Workspace and GeomAIWorkspace

### DIFF
--- a/src/ansys/simai/core/api/geomai/workspaces.py
+++ b/src/ansys/simai/core/api/geomai/workspaces.py
@@ -102,3 +102,15 @@ class GeomAIWorkspaceClientMixin(ApiClientMixin):
         request_json = {}
         request_json["name"] = name
         self._patch(f"geomai/workspaces/{workspace_id}", json=request_json, return_json=False)
+
+    def get_geomai_workspace_model_configuration(self, workspace_id: str):
+        """Get the model configuration used for the given GeomAI workspace.
+
+        Args:
+            workspace_id: ID of the workspace.
+
+        Raises:
+            ansys.simai.core.errors.NotFoundError: If no workspace with that ID exists.
+            ansys.simai.core.errors.ApiClientError: On other HTTP errors.
+        """
+        return self._get(f"geomai/workspaces/{workspace_id}/model/configuration")

--- a/src/ansys/simai/core/api/workspace.py
+++ b/src/ansys/simai/core/api/workspace.py
@@ -110,3 +110,15 @@ class WorkspaceClientMixin(ApiClientMixin):
         request_json = {}
         request_json["name"] = name
         self._patch(f"workspaces/{workspace_id}", json=request_json, return_json=False)
+
+    def get_workspace_model_configuration(self, workspace_id: str):
+        """Get the model configuration used for the given workspace.
+
+        Args:
+            workspace_id: ID of the workspace.
+
+        Raises:
+            ansys.simai.core.errors.NotFoundError: If no workspace with that ID exists.
+            ansys.simai.core.errors.ApiClientError: On other HTTP errors.
+        """
+        return self._get(f"workspaces/{workspace_id}/model/configuration")

--- a/src/ansys/simai/core/data/geomai/workspaces.py
+++ b/src/ansys/simai/core/data/geomai/workspaces.py
@@ -24,6 +24,7 @@ import json
 from typing import TYPE_CHECKING, BinaryIO, List, Optional, Union
 
 from ansys.simai.core.data.base import DataModel, Directory
+from ansys.simai.core.data.geomai.models import GeomAIModelConfiguration
 from ansys.simai.core.data.types import File, Identifiable, get_id_from_identifiable
 
 if TYPE_CHECKING:
@@ -37,6 +38,7 @@ class GeomAIWorkspace(DataModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._model_manifest = None
+        self._model_configuration = None
 
     def __repr__(self) -> str:
         return f"<GeomAIWorkspace: {self.id}, {self.name}>"
@@ -45,6 +47,14 @@ class GeomAIWorkspace(DataModel):
     def name(self) -> str:
         """Name of the workspace."""
         return self.fields["name"]
+
+    @property
+    def model_configuration(self) -> GeomAIModelConfiguration:
+        """Model configuration used in the workspace."""
+        if self._model_configuration is None:
+            model_config = self._client._api.get_workspace_model_configuration(self.id)
+            self._model_configuration = GeomAIModelConfiguration(**model_config)
+        return self._model_configuration
 
     def rename(self, new_name: str) -> None:
         """Rename the workspace.

--- a/src/ansys/simai/core/data/workspaces.py
+++ b/src/ansys/simai/core/data/workspaces.py
@@ -25,6 +25,7 @@ from pprint import pformat
 from typing import Any, BinaryIO, Dict, List, Optional, Union
 
 from ansys.simai.core.data.base import DataModel, Directory
+from ansys.simai.core.data.model_configuration import ModelConfiguration
 from ansys.simai.core.data.types import File, Identifiable, get_id_from_identifiable
 
 
@@ -76,6 +77,7 @@ class Workspace(DataModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._model_manifest = None
+        self._model_configuration = None
 
     def __repr__(self) -> str:
         return f"<Workspace: {self.id}, {self.name}>"
@@ -104,6 +106,16 @@ class Workspace(DataModel):
                 self._client._api.get_workspace_model_manifest(self.id)
             )
         return self._model_manifest
+
+    @property
+    def model_configuration(self) -> ModelConfiguration:
+        """Model configuration used in the workspace."""
+        if self._model_configuration is None:
+            model_config = self._client._api.get_workspace_model_configuration(self.id)
+            self._model_configuration = ModelConfiguration._from_payload(
+                project=self._client.projects.get(self.fields["project"]), **model_config
+            )
+        return self._model_configuration
 
     def rename(self, new_name: str) -> None:
         """Rename the workspace.

--- a/tests/geomai/test_geomai_workspaces.py
+++ b/tests/geomai/test_geomai_workspaces.py
@@ -22,8 +22,16 @@
 
 from typing import TYPE_CHECKING
 
+from ansys.simai.core.data.geomai.models import GeomAIModelConfiguration
+
 if TYPE_CHECKING:
     from ansys.simai.core.data.geomai.workspaces import GeomAIWorkspace
+
+
+NB_EPOCHS = 50
+NB_LATENT_PARAMS = 10
+
+MODEL_CONF_RAW = {"nb_epochs": NB_EPOCHS, "nb_latent_param": NB_LATENT_PARAMS, "build_preset": None}
 
 
 def test_geomai_workspace_download_mer(simai_client, httpx_mock):
@@ -81,3 +89,19 @@ def test_geomai_workspace_get_latent_parameters(simai_client, httpx_mock):
     latent_parameters = workspace.get_latent_parameters()
     assert isinstance(latent_parameters, dict)
     assert latent_parameters == {"geometry1": [1, 2, 3]}
+
+
+def test_get_workspace_model_configuration(mocker, simai_client, httpx_mock, training_data_factory):
+    workspace: GeomAIWorkspace = simai_client.geomai._workspace_directory._model_from(
+        {"id": "0011", "name": "riri"}
+    )
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://test.test/workspaces/0011/model/configuration",
+        json=MODEL_CONF_RAW,
+        status_code=200,
+    )
+
+    assert workspace.model_configuration.model_dump() == MODEL_CONF_RAW
+    assert isinstance(workspace.model_configuration, GeomAIModelConfiguration)


### PR DESCRIPTION
Add `model_configuration` property that returns a `ModelConfiguration` or `GeomAIModelConfiguration` object.

[sc-32880]