### PR TITLE
chore: increase httpx default timeout

### DIFF
--- a/src/ansys/simai/core/api/mixin.py
+++ b/src/ansys/simai/core/api/mixin.py
@@ -75,7 +75,7 @@ class ApiClientMixin:
 
         # TODO: stop following redirects
         self._session = httpx.Client(
-            mounts=mounts, headers=self._get_user_agent(), follow_redirects=True
+            mounts=mounts, headers=self._get_user_agent(), follow_redirects=True, timeout=15.0
         )
         self._url_prefix = config.url
         self._session.auth = Authenticator(config, self._session)


### PR DESCRIPTION
Some people are having read/write timeouts for unknown reasons (not just to our servers but also to s3 so likely spotty connection ?). This hopefully will help a bit scripts survive for users with spotty connections.