### PR TITLE
feat: add method to retrieve latent parameters as dict in GeomAIWorkspace

### DIFF
--- a/src/ansys/simai/core/data/geomai/workspaces.py
+++ b/src/ansys/simai/core/data/geomai/workspaces.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import json
 from typing import TYPE_CHECKING, BinaryIO, List, Optional, Union
 
 from ansys.simai.core.data.base import DataModel, Directory
@@ -79,6 +80,14 @@ class GeomAIWorkspace(DataModel):
             ``None`` if a file is specified or a binary file-object otherwise.
         """
         return self._client._api.download_geomai_workspace_latent_parameters(self.id, file)
+
+    def get_latent_parameters(self) -> dict[str, List[float]]:
+        """Get the dictionary mapping geometry names to their latent parameter vectors for the model's training data."""
+        data = self._client._api.download_geomai_workspace_latent_parameters(self.id, None)
+        if data is None:
+            return {}
+        latent_parameters = json.loads(data.read().decode("utf-8"))
+        return latent_parameters
 
     def download_model_evaluation_report(
         self, file: Optional[File] = None

--- a/tests/geomai/test_geomai_workspaces.py
+++ b/tests/geomai/test_geomai_workspaces.py
@@ -65,3 +65,19 @@ def test_geomai_workspace_rename(simai_client, httpx_mock):
 
     workspace.rename("fifi")
     assert workspace.name == "fifi"
+
+
+def test_geomai_workspace_get_latent_parameters(simai_client, httpx_mock):
+    workspace: GeomAIWorkspace = simai_client.geomai._workspace_directory._model_from(
+        {"id": "abc123", "name": "HL3"}
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://test.test/geomai/workspaces/{workspace.id}/model/latent-parameters-json",
+        text='{"geometry1": [1,2,3]}',
+        status_code=200,
+    )
+
+    latent_parameters = workspace.get_latent_parameters()
+    assert isinstance(latent_parameters, dict)
+    assert latent_parameters == {"geometry1": [1, 2, 3]}


### PR DESCRIPTION
This method should help users to have the latent parameters of a workspace as dict object instead of having only the option to download the json file locally.

[sc-34759]