### PR TITLE
fix: replace truthy fallback with explicit None check

### DIFF
--- a/src/ansys/simai/core/data/geometries.py
+++ b/src/ansys/simai/core/data/geometries.py
@@ -185,7 +185,7 @@ class Geometry(UploadableResourceMixin, ComputableDataModel):
             logger.warning(
                 "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead."
             )
-        bc = build_scalars(scalars if scalars else boundary_conditions, **kwargs)
+        bc = build_scalars(scalars if scalars is not None else boundary_conditions, **kwargs)
         prediction_response = self._client._api.run_prediction(self.id, boundary_conditions=bc)
         return self._client.predictions._model_from(prediction_response)
 

--- a/src/ansys/simai/core/data/model_configuration.py
+++ b/src/ansys/simai/core/data/model_configuration.py
@@ -407,9 +407,15 @@ class ModelConfiguration:
             logger.warning(
                 "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead."
             )
-        self.__dict__["input"].scalars = model_input.scalars or model_input.boundary_conditions
+        self.__dict__["input"].scalars = (
+            model_input.scalars
+            if model_input.scalars is not None
+            else model_input.boundary_conditions
+        )
         self.__dict__["input"].boundary_conditions = (
-            model_input.scalars or model_input.boundary_conditions
+            model_input.scalars
+            if model_input.scalars is not None
+            else model_input.boundary_conditions
         )
 
     def __get_input(self):

--- a/src/ansys/simai/core/data/selections.py
+++ b/src/ansys/simai/core/data/selections.py
@@ -64,7 +64,7 @@ class Point:
             )
 
         self._geometry = geometry
-        self._scalars = scalars or boundary_conditions
+        self._scalars = scalars if scalars is not None else boundary_conditions
         self._prediction: Optional[Prediction] = None
 
     @property


### PR DESCRIPTION
There is a bug when you create a Point with `scalars = {}` ,  `self._scalars` became `None` where it should be an empty dict.

[sc-36096]