### PR TITLE
feat: add training data rename support

### DIFF
--- a/src/ansys/simai/core/api/training_data.py
+++ b/src/ansys/simai/core/api/training_data.py
@@ -38,6 +38,9 @@ class TrainingDataClientMixin(ApiClientMixin):
     def get_training_data(self, id: str) -> Dict[str, Any]:
         return self._get(f"training-data/{id}")
 
+    def rename_training_data(self, id: str, new_name: str) -> None:
+        self._patch(f"training-data/{id}", json={"name": new_name})
+
     def get_training_data_by_name(self, name: str) -> Dict[str, Any]:
         return self._get(f"training-data/name/{quote(name)}")
 

--- a/src/ansys/simai/core/data/training_data.py
+++ b/src/ansys/simai/core/data/training_data.py
@@ -73,6 +73,15 @@ class TrainingData(ComputableDataModel):
         """Name of the training data."""
         return self.fields["name"]
 
+    def rename(self, new_name: str) -> None:
+        """Change the name of the training data.
+
+        Args:
+            new_name: New name to give to the training data object.
+        """
+        self._client._api.rename_training_data(self.id, new_name=new_name)
+        self.reload()
+
     @property
     def parts(self) -> List["TrainingDataPart"]:
         """List of all :class:`parts<ansys.simai.core.data.training_data_parts.TrainingDataPart>`

--- a/tests/test_training_data.py
+++ b/tests/test_training_data.py
@@ -225,3 +225,24 @@ def test_get_training_data_invalid_arguments(simai_client):
     with pytest.raises(InvalidArguments) as e:
         simai_client.training_data.get(id="td-123", name="My Training Data")
     assert str(e.value) == "Cannot specify both 'id' and 'name' arguments."
+
+
+def test_rename_training_data(simai_client, httpx_mock, training_data_factory):
+    td: TrainingData = training_data_factory(id="39646")
+    httpx_mock.add_response(
+        method="PATCH",
+        url="https://test.test/training-data/39646",
+        status_code=204,
+    )
+    # because rename triggers a reload of the object from the server
+    httpx_mock.add_response(
+        method="GET",
+        url="https://test.test/training-data/39646",
+        json={"id": "39646", "name": "the new name"},
+        status_code=200,
+    )
+
+    td.rename("the new name")
+
+    assert td.id == "39646"
+    assert td.name == "the new name"


### PR DESCRIPTION
Add training data renaming support.

Awaiting API to be merged.

[sc-35630]