### PR TITLE
Add doc on new NPO features

### DIFF
--- a/doc/source/examples/01_pysimai_ex/04-non_parametric_optimization.py
+++ b/doc/source/examples/01_pysimai_ex/04-non_parametric_optimization.py
@@ -64,6 +64,16 @@ Use 5 iterations for quick tests, or 100+ for production runs.
 
 **Objective**: The performance indicator to optimize (e.g., minimize drag, maximize lift).
 Only one objective can be defined for non-parametric optimization.
+
+**Offline token**: Required for server-side optimization. Allows the server to authenticate
+on your behalf while uploading geometries at each iteration. Generated via
+``simai.me.generate_offline_token()`` and valid for 30 days.
+
+**Detail level**: Controls deformation refinement (integer from 1 to 10, default: 5).
+Low values produce coarse shape changes; high values allow fine local adjustments.
+
+**Part morphing**: Optional constraint that restricts deformation to specific geometry parts
+identified by a ``PartId`` cell field.
 """
 
 ###############################################################################
@@ -105,6 +115,7 @@ plotter.show()
 import os
 
 import ansys.simai.core as asc
+from ansys.simai.core.data.optimizations import OptimizationPartMorphingSchema
 from ansys.simai.core.data.predictions import Prediction
 
 ORGANIZATION_NAME = "<your_organization_name>"
@@ -114,12 +125,27 @@ CHOSEN_GEOMETRY_NAME = "<your_geometry_file.vtp>"
 # A bounding box must be defined as [xmin, xmax, ymin, ymax, zmin, zmax]
 BOUNDING_BOXES = [[-0.07, 0.15, -0.06, 0.12, -0.09, 0.15]]
 NUMBER_OF_ITERATIONS = 10
+# Maximum displacement per bounding box (one value per box, same unit as geometry)
+MAX_DISPLACEMENT = [0.1]
 # Symmetry constraints (e.g., ["X"] for YZ plane symmetry)
 SYMMETRIES = []
 # Objective to maximize (use minimize parameter for minimization)
 OBJECTIVE = ["<global_coefficient_objective>"]
+# Detail level controls deformation refinement (integer from 1 to 10, default: 5)
+DETAIL_LEVEL = 5
 # Output folder for results
 OUTPUT_FOLDER = "simai_output"
+
+# Part morphing (optional): restricts deformation to specific parts of the
+# geometry identified by a ``PartId`` cell field. ``continuity_constraint``
+# (0 to 1) controls how smoothly the deformed region blends with the rest.
+# A value of 0 means no continuity enforcement; 1 gives the best continuity
+# but reduces the overall deformation magnitude (increase ``detail_level``
+# to compensate).
+# PART_MORPHING = OptimizationPartMorphingSchema(
+#     part_ids=[0],              # IDs matching the ``PartId`` cell field
+#     continuity_constraint=0.5  # 0 = unconstrained, 1 = maximum continuity
+# )
 
 ###############################################################################
 # Initialize SimAI client and workspace
@@ -135,6 +161,20 @@ geometry = simai.geometries.get(workspace=workspace, name=CHOSEN_GEOMETRY_NAME)
 print(f"Baseline geometry: {geometry.name}")
 
 ###############################################################################
+# Generate an offline token
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# The optimization runs server-side. At each iteration the geometry
+# corresponding to the current step is uploaded to your workspace.
+# An ``offline_token`` is required so that the server can authenticate
+# on your behalf during this process.
+#
+# Generating the token requires a one-time manual action (browser login).
+# Once generated, the token is valid for 30 days. You can generate as many
+# tokens as needed.
+
+offline_token = simai.me.generate_offline_token()
+
+###############################################################################
 # Start the optimization
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Launch the optimization with the configured parameters.
@@ -143,12 +183,16 @@ print(f"Baseline geometry: {geometry.name}")
 
 optimization_result = simai.optimizations.run_non_parametric(
     geometry=geometry,
+    offline_token=offline_token,
     bounding_boxes=BOUNDING_BOXES,
+    max_displacement=MAX_DISPLACEMENT,
     scalars={},  # Scalars must match your workspace configuration
     n_iters=NUMBER_OF_ITERATIONS,
     symmetries=SYMMETRIES,
+    detail_level=DETAIL_LEVEL,
     maximize=OBJECTIVE,  # Use 'minimize' parameter for minimization objectives
     show_progress=True,
+    # part_morphing=PART_MORPHING,  # Uncomment to enable part morphing
 )
 
 ###############################################################################

--- a/doc/source/examples/01_pysimai_ex/04-non_parametric_optimization.py
+++ b/doc/source/examples/01_pysimai_ex/04-non_parametric_optimization.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# ruff: noqa: ERA001
+
 """.. _ref_non_parametric_optimization:
 
 Non-parametric optimization
@@ -115,8 +117,9 @@ plotter.show()
 import os
 
 import ansys.simai.core as asc
-from ansys.simai.core.data.optimizations import OptimizationPartMorphingSchema
 from ansys.simai.core.data.predictions import Prediction
+
+# from ansys.simai.core.data.optimizations import OptimizationPartMorphingSchema
 
 ORGANIZATION_NAME = "<your_organization_name>"
 WORKSPACE_NAME = "<your_workspace_name>"

--- a/doc/source/examples/01_pysimai_ex/04-non_parametric_optimization.py
+++ b/doc/source/examples/01_pysimai_ex/04-non_parametric_optimization.py
@@ -119,8 +119,6 @@ import os
 import ansys.simai.core as asc
 from ansys.simai.core.data.predictions import Prediction
 
-# from ansys.simai.core.data.optimizations import OptimizationPartMorphingSchema
-
 ORGANIZATION_NAME = "<your_organization_name>"
 WORKSPACE_NAME = "<your_workspace_name>"
 CHOSEN_GEOMETRY_NAME = "<your_geometry_file.vtp>"
@@ -139,16 +137,24 @@ DETAIL_LEVEL = 5
 # Output folder for results
 OUTPUT_FOLDER = "simai_output"
 
-# Part morphing (optional): restricts deformation to specific parts of the
-# geometry identified by a ``PartId`` cell field. ``continuity_constraint``
-# (0 to 1) controls how smoothly the deformed region blends with the rest.
-# A value of 0 means no continuity enforcement; 1 gives the best continuity
-# but reduces the overall deformation magnitude (increase ``detail_level``
-# to compensate).
-# PART_MORPHING = OptimizationPartMorphingSchema(
-#     part_ids=[0],              # IDs matching the ``PartId`` cell field
-#     continuity_constraint=0.5  # 0 = unconstrained, 1 = maximum continuity
-# )
+###############################################################################
+# Part morphing (optional)
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+# Part morphing restricts deformation to specific parts of the geometry
+# identified by a ``PartId`` cell field. The ``continuity_constraint``
+# parameter (0 to 1) controls how smoothly the deformed region blends
+# with the rest. A value of 0 means no continuity enforcement; 1 gives
+# the best continuity but reduces the overall deformation magnitude.
+# Before adjusting ``detail_level`` to compensate, first experiment with
+# different ``continuity_constraint`` values to find the right balance
+# between interface smoothness and deformation magnitude.
+
+from ansys.simai.core.data.optimizations import OptimizationPartMorphingSchema
+
+PART_MORPHING = OptimizationPartMorphingSchema(
+    part_ids=[0],              # IDs matching the ``PartId`` cell field
+    continuity_constraint=0.5  # 0 = unconstrained, 1 = maximum continuity
+)
 
 ###############################################################################
 # Initialize SimAI client and workspace
@@ -171,7 +177,7 @@ print(f"Baseline geometry: {geometry.name}")
 # An ``offline_token`` is required so that the server can authenticate
 # on your behalf during this process.
 #
-# Generating the token requires a one-time manual action (browser login).
+# Generating the token requires a manual action (browser login).
 # Once generated, the token is valid for 30 days. You can generate as many
 # tokens as needed.
 

--- a/doc/source/examples/01_pysimai_ex/04-non_parametric_optimization.py
+++ b/doc/source/examples/01_pysimai_ex/04-non_parametric_optimization.py
@@ -201,7 +201,7 @@ optimization_result = simai.optimizations.run_non_parametric(
     detail_level=DETAIL_LEVEL,
     maximize=OBJECTIVE,  # Use 'minimize' parameter for minimization objectives
     show_progress=True,
-    # part_morphing=PART_MORPHING,  # Uncomment to enable part morphing
+    part_morphing=PART_MORPHING,  # Comment to disable part morphing
 )
 
 ###############################################################################

--- a/doc/source/examples/01_pysimai_ex/04-non_parametric_optimization.py
+++ b/doc/source/examples/01_pysimai_ex/04-non_parametric_optimization.py
@@ -152,8 +152,8 @@ OUTPUT_FOLDER = "simai_output"
 from ansys.simai.core.data.optimizations import OptimizationPartMorphingSchema
 
 PART_MORPHING = OptimizationPartMorphingSchema(
-    part_ids=[0],              # IDs matching the ``PartId`` cell field
-    continuity_constraint=0.5  # 0 = no constraint, 1 = maximum continuity
+    part_ids=[0],  # IDs matching the ``PartId`` cell field
+    continuity_constraint=0.5,  # 0 = no constraint, 1 = maximum continuity
 )
 
 ###############################################################################

--- a/doc/source/examples/01_pysimai_ex/04-non_parametric_optimization.py
+++ b/doc/source/examples/01_pysimai_ex/04-non_parametric_optimization.py
@@ -153,7 +153,7 @@ from ansys.simai.core.data.optimizations import OptimizationPartMorphingSchema
 
 PART_MORPHING = OptimizationPartMorphingSchema(
     part_ids=[0],              # IDs matching the ``PartId`` cell field
-    continuity_constraint=0.5  # 0 = unconstrained, 1 = maximum continuity
+    continuity_constraint=0.5  # 0 = no constraint, 1 = maximum continuity
 )
 
 ###############################################################################

--- a/doc/source/user_guide/automorphing/configure_automorphing.rst
+++ b/doc/source/user_guide/automorphing/configure_automorphing.rst
@@ -25,7 +25,7 @@ The optimization runs server-side. At each iteration, the geometry corresponding
 current step is uploaded to your workspace. To allow the server to authenticate on your
 behalf during this process, you must provide an ``offline_token``.
 
-Generating the token requires a manual action (a browser login prompt).
+Generating the token requires a manual action from you (a browser login prompt).
 Once generated, the token is valid for **30 days**. You can generate as many tokens as needed.
 
 .. code-block:: Python
@@ -166,7 +166,7 @@ In those cases, errors are raised indicating the acceptable range:
   .. code-block:: text
 
       InputValueError: The number of points to be deformed in the geometry ('nb_point') and
-      this detail level ('current_detail_level') might lead to OOM. The maximum detail level is 'max_detail_level'.
+      this detail level ('current_detail_level') might lead to Out of Memory. The maximum detail level is 'max_detail_level'.
 
 Part morphing
 ------------------------------

--- a/doc/source/user_guide/automorphing/configure_automorphing.rst
+++ b/doc/source/user_guide/automorphing/configure_automorphing.rst
@@ -130,7 +130,7 @@ The ``show_progress`` parameter determines whether progress updates are displaye
 It is generally recommended to enable this feature during development and testing phases
 so that you can monitor the process and detect potential issues early.
 
-Detail level (detail_level)
+Detail level
 ----------------------------
 
 The ``detail_level`` parameter adjusts how much deformation can be applied to the geometry.
@@ -168,7 +168,7 @@ In those cases, errors are raised indicating the acceptable range:
       InputValueError: The number of points to be deformed in the geometry ('nb_point') and
       this detail level ('m') might lead to OOM. The maximum detail level is 'n'.
 
-Part morphing (part_morphing)
+Part morphing
 ------------------------------
 
 The ``part_morphing`` parameter provides user-defined constraints to restrict deformation to

--- a/doc/source/user_guide/automorphing/configure_automorphing.rst
+++ b/doc/source/user_guide/automorphing/configure_automorphing.rst
@@ -181,7 +181,7 @@ exactly named ``PartId``.
 The ``continuity_constraint`` parameter controls how much the continuity at the interface
 between deformed and non-deformed parts is enforced. It can be set between **0** and **1** (inclusive):
 
-- At **0**, the continuity is not constrained at all during the optimization.
+- At **0**, the continuity is not constrained during the optimization.
 - At **1**, the continuity enforcement is at its maximum.
 
 .. note::

--- a/doc/source/user_guide/automorphing/configure_automorphing.rst
+++ b/doc/source/user_guide/automorphing/configure_automorphing.rst
@@ -18,7 +18,7 @@ If the optimization does not show improvement after several optimization process
 try using a different geometry from the training data as the baseline (``geometry``).
 Always make sure the geometry is clean and of high quality, as issues like mesh errors can negatively impact the optimization process.
 
-Offline token (offline_token)
+Offline token
 -----------------------------
 
 The optimization runs server-side. At each iteration, the geometry corresponding to the

--- a/doc/source/user_guide/automorphing/configure_automorphing.rst
+++ b/doc/source/user_guide/automorphing/configure_automorphing.rst
@@ -25,7 +25,7 @@ The optimization runs server-side. At each iteration, the geometry corresponding
 current step is uploaded to your workspace. To allow the server to authenticate on your
 behalf during this process, you must provide an ``offline_token``.
 
-Generating the token requires a one-time manual action (a browser login prompt).
+Generating the token requires a manual action (a browser login prompt).
 Once generated, the token is valid for **30 days**. You can generate as many tokens as needed.
 
 .. code-block:: Python
@@ -158,15 +158,15 @@ In those cases, errors are raised indicating the acceptable range:
 
   .. code-block:: text
 
-      InputValueError: The size of box 'i' is too small for the chosen detail level.
-      The minimum detail level is 'n'.
+      InputValueError: The size of box 'box_id' is too small for the chosen detail level.
+      The minimum detail level is 'min_detail_level'.
 
 - If the value is too high:
 
   .. code-block:: text
 
       InputValueError: The number of points to be deformed in the geometry ('nb_point') and
-      this detail level ('m') might lead to OOM. The maximum detail level is 'n'.
+      this detail level ('current_detail_level') might lead to OOM. The maximum detail level is 'max_detail_level'.
 
 Part morphing
 ------------------------------

--- a/doc/source/user_guide/automorphing/configure_automorphing.rst
+++ b/doc/source/user_guide/automorphing/configure_automorphing.rst
@@ -18,6 +18,27 @@ If the optimization does not show improvement after several optimization process
 try using a different geometry from the training data as the baseline (``geometry``).
 Always make sure the geometry is clean and of high quality, as issues like mesh errors can negatively impact the optimization process.
 
+Offline token (offline_token)
+-----------------------------
+
+The optimization runs server-side. At each iteration, the geometry corresponding to the
+current step is uploaded to your workspace. To allow the server to authenticate on your
+behalf during this process, you must provide an ``offline_token``.
+
+Generating the token requires a one-time manual action (a browser login prompt).
+Once generated, the token is valid for **30 days**. You can generate as many tokens as needed.
+
+.. code-block:: Python
+
+    offline_token = simai_client.me.generate_offline_token()
+
+If no ``offline_token`` is passed as a function parameter or defined in the client configuration,
+server-side optimization will not work.
+
+.. note::
+
+    For more information on managing tokens, see :ref:`current_user`.
+
 Bounding boxes
 ---------------
 
@@ -108,3 +129,77 @@ Show progress
 The ``show_progress`` parameter determines whether progress updates are displayed during the optimization run.
 It is generally recommended to enable this feature during development and testing phases
 so that you can monitor the process and detect potential issues early.
+
+Detail level (detail_level)
+----------------------------
+
+The ``detail_level`` parameter adjusts how much deformation can be applied to the geometry.
+It is an integer from 1 to 10 and defaults to **5** when not provided.
+
+- **Low values** produce coarse deformations with only rough shape changes.
+- **High values** allow fine details and subtle local adjustments.
+
+For a given value of ``detail_level``, the deformation refinement remains the same regardless of
+the bounding box size. When using multiple bounding boxes, this ensures the same amount of
+deformation in each box.
+
+.. code-block:: Python
+
+    detail_level = 4
+
+.. warning::
+
+    The total number of points to be deformed cannot be greater than **6x10⁷**.
+
+Depending on the baseline geometry and bounding boxes, some values of ``detail_level`` may not be achievable.
+In those cases, errors are raised indicating the acceptable range:
+
+- If the value is too low:
+
+  .. code-block:: text
+
+      InputValueError: The size of box 'i' is too small for the chosen detail level.
+      The minimum detail level is 'n'.
+
+- If the value is too high:
+
+  .. code-block:: text
+
+      InputValueError: The number of points to be deformed in the geometry ('nb_point') and
+      this detail level ('m') might lead to OOM. The maximum detail level is 'n'.
+
+Part morphing (part_morphing)
+------------------------------
+
+The ``part_morphing`` parameter provides user-defined constraints to restrict deformation to
+specific parts of the geometry.
+
+The parts to be deformed are identified by their IDs, provided as a list of integers in
+``part_ids``. These IDs must correspond to a cell field of the baseline geometry
+exactly named ``PartId``.
+
+The ``continuity_constraint`` parameter controls how much the continuity at the interface
+between deformed and non-deformed parts is enforced. It can be set between **0** and **1** (inclusive):
+
+- At **0**, the continuity is not constrained at all during the optimization.
+- At **1**, the continuity enforcement is at its maximum.
+
+.. note::
+
+    Increasing ``continuity_constraint`` reduces the overall deformation magnitude.
+    To compensate, you can increase the ``detail_level`` value.
+
+.. code-block:: Python
+
+    from ansys.simai.core.data.optimizations import OptimizationPartMorphingSchema
+
+    part_morphing = OptimizationPartMorphingSchema(
+        part_ids=[1, 2],
+        continuity_constraint=0.8
+    )
+
+.. warning::
+
+    For a given configuration of ``detail_level``, ``bounding_boxes``, and other parameters that
+    passes validation, adding ``part_morphing`` may trigger an out-of-memory error. If this occurs,
+    reduce the ``detail_level`` or simplify the bounding box configuration.


### PR DESCRIPTION
Added warnings and comments on the user guide on how to use the new parameters

Added the missing token and Part Morphing in the example code

Question: is there too much warning? Should it be simpler in the doc?