### PR TITLE
fix: predictions.run() supports boundary_conditions

### DIFF
--- a/src/ansys/simai/core/data/lists.py
+++ b/src/ansys/simai/core/data/lists.py
@@ -30,7 +30,12 @@ if TYPE_CHECKING:
     from ansys.simai.core.data.predictions import Prediction
     from ansys.simai.core.data.selections import Selection
 
-from ansys.simai.core.errors import InvalidArguments, _foreach_despite_errors, _map_despite_errors
+from ansys.simai.core.errors import (
+    InvalidArguments,
+    PySimAIDepreciationWarning,
+    _foreach_despite_errors,
+    _map_despite_errors,
+)
 
 T = TypeVar("T", bound=PostProcessing)
 
@@ -92,8 +97,8 @@ class ExportablePPList(PPList, Generic[T]):
         if format == "csv":
             warnings.warn(
                 "The ``csv`` option is being deprecated. Use the ``csv.zip`` option instead",
-                PendingDeprecationWarning,
-                stacklevel=1,
+                PySimAIDepreciationWarning,
+                stacklevel=2,
             )
         if len(self) < 1:
             raise InvalidArguments("Selection contains no exportable postprocessing.")

--- a/src/ansys/simai/core/data/model_configuration.py
+++ b/src/ansys/simai/core/data/model_configuration.py
@@ -19,12 +19,11 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-import logging
+import warnings
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any, List, Literal, Optional
 
-from ansys.simai.core.errors import InvalidArguments, ProcessingError
+from ansys.simai.core.errors import InvalidArguments, ProcessingError, PySimAIDepreciationWarning
 from ansys.simai.core.utils.misc import dict_get
 
 if TYPE_CHECKING:
@@ -36,9 +35,6 @@ SupportedBuildPresets = {
     "2_days": "default",
     "7_days": "long",
 }
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -404,8 +400,10 @@ class ModelConfiguration:
 
         # DEPRECATED
         if model_input.boundary_conditions:
-            logger.warning(
-                "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead."
+            warnings.warn(
+                "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead.",
+                PySimAIDepreciationWarning,
+                stacklevel=2,
             )
         self.__dict__["input"].scalars = (
             model_input.scalars
@@ -489,8 +487,10 @@ class ModelConfiguration:
             self.input.boundary_conditions = list(scalars.keys())
         # DEPRECATED
         if boundary_conditions is not None and self.input.boundary_conditions is None:
-            logger.warning(
-                "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead."
+            warnings.warn(
+                "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead.",
+                PySimAIDepreciationWarning,
+                stacklevel=2,
             )
             self.input.scalars = list(boundary_conditions.keys())
             self.input.boundary_conditions = list(boundary_conditions.keys())

--- a/src/ansys/simai/core/data/optimizations.py
+++ b/src/ansys/simai/core/data/optimizations.py
@@ -35,7 +35,7 @@ from ansys.simai.core.data.types import (
     get_id_from_identifiable,
     get_object_from_identifiable,
 )
-from ansys.simai.core.errors import InvalidArguments, NotFoundError
+from ansys.simai.core.errors import InvalidArguments, NotFoundError, PySimAIDepreciationWarning
 
 logger = logging.getLogger(__name__)
 
@@ -421,7 +421,8 @@ class OptimizationDirectory(Directory[Optimization]):
         if scalars is None and boundary_conditions is not None:
             warnings.warn(
                 "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead.",
-                stacklevel=1,
+                PySimAIDepreciationWarning,
+                stacklevel=2,
             )
             scalars = boundary_conditions
         _validate_n_iters(n_iters)
@@ -600,7 +601,8 @@ class LegacyOptimizationDirectory(Directory[LegacyOptimization]):
         if scalars is None and boundary_conditions is not None:
             warnings.warn(
                 "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead.",
-                stacklevel=1,
+                PySimAIDepreciationWarning,
+                stacklevel=2,
             )
             scalars = boundary_conditions
         _validate_n_iters(n_iters)

--- a/src/ansys/simai/core/data/predictions.py
+++ b/src/ansys/simai/core/data/predictions.py
@@ -19,8 +19,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
 import logging
+import warnings
 from typing import Any, Dict, List, Optional
 
 from ansys.simai.core.data.base import ComputableDataModel, Directory
@@ -34,6 +34,7 @@ from ansys.simai.core.data.types import (
     get_id_from_identifiable,
 )
 from ansys.simai.core.data.workspaces import Workspace
+from ansys.simai.core.errors import PySimAIDepreciationWarning
 
 logger = logging.getLogger(__name__)
 
@@ -75,8 +76,10 @@ class Prediction(ComputableDataModel):
     @property
     def boundary_conditions(self) -> BoundaryConditions:
         """**(Deprecated)** Boundary conditions of the prediction."""
-        logger.warning(
-            "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead."
+        warnings.warn(
+            "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead.",
+            PySimAIDepreciationWarning,
+            stacklevel=2,
         )
         return self.fields["boundary_conditions"]
 
@@ -172,8 +175,10 @@ class PredictionDirectory(Directory[Prediction]):
         """**(Deprecated)** Information on the boundary conditions expected by the model of the current workspace.
         For example, the prediction's input.
         """
-        logger.warning(
-            "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead."
+        warnings.warn(
+            "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead.",
+            PySimAIDepreciationWarning,
+            stacklevel=2,
         )
         return self._client.current_workspace.model_manifest.boundary_conditions
 
@@ -292,10 +297,12 @@ class PredictionDirectory(Directory[Prediction]):
 
         """
         if boundary_conditions is not None:
-            logger.warning(
-                "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead."
+            warnings.warn(
+                "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead.",
+                PySimAIDepreciationWarning,
+                stacklevel=2,
             )
-        bc = build_scalars(scalars, **kwargs)
+        bc = build_scalars(scalars if scalars is not None else boundary_conditions, **kwargs)
         geometry = self._client.geometries.get(id=get_id_from_identifiable(geometry))
         prediction = geometry.run_prediction(scalars=bc)
         for location, warning_message in prediction.fields.get("warnings", {}).items():

--- a/src/ansys/simai/core/data/selections.py
+++ b/src/ansys/simai/core/data/selections.py
@@ -19,8 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-import logging
+import warnings
 from typing import Dict, List, Optional, Union
 
 from ansys.simai.core.data.geometries import Geometry
@@ -32,14 +31,12 @@ from ansys.simai.core.data.types import (
     are_scalars_equal,
     is_scalars,
 )
-from ansys.simai.core.errors import _foreach_despite_errors
+from ansys.simai.core.errors import PySimAIDepreciationWarning, _foreach_despite_errors
 from ansys.simai.core.utils.numerical import (
     DEFAULT_COMPARISON_EPSILON,
     validate_tolerance_parameter,
 )
 from ansys.simai.core.utils.validation import _enforce_as_list_passing_predicate
-
-logger = logging.getLogger(__name__)
 
 
 class Point:
@@ -59,10 +56,11 @@ class Point:
         if scalars is None and boundary_conditions is None:
             raise ValueError("Provide either 'scalars' or 'boundary_conditions'")
         if boundary_conditions is not None:
-            logger.warning(
-                "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead."
+            warnings.warn(
+                "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead.",
+                PySimAIDepreciationWarning,
+                stacklevel=2,
             )
-
         self._geometry = geometry
         self._scalars = scalars if scalars is not None else boundary_conditions
         self._prediction: Optional[Prediction] = None
@@ -77,8 +75,10 @@ class Point:
         """**(Deprecated)** :class:`~ansys.simai.core.data.types.BoundaryConditions` object for the :class:`Point`
         instance.
         """
-        logger.warning(
-            "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead."
+        warnings.warn(
+            "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead.",
+            PySimAIDepreciationWarning,
+            stacklevel=2,
         )
         return self._scalars
 
@@ -103,8 +103,10 @@ class Point:
     ):
         """Run the prediction on the geometry for this scalar."""
         if boundary_conditions is not None:
-            logger.warning(
-                "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead."
+            warnings.warn(
+                "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead.",
+                PySimAIDepreciationWarning,
+                stacklevel=2,
             )
             scalars = boundary_conditions
 
@@ -147,8 +149,10 @@ class Selection:
         if scalars is None and boundary_conditions is None:
             raise ValueError("Provide either 'scalars' or 'boundary_conditions'")
         if boundary_conditions is not None:
-            logger.warning(
-                "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead."
+            warnings.warn(
+                "The 'boundary_conditions' parameter is deprecated and will be removed in a future release. Please use the 'scalars' parameter instead.",
+                PySimAIDepreciationWarning,
+                stacklevel=2,
             )
             scalars = boundary_conditions
 
@@ -202,8 +206,10 @@ class Selection:
         """**(Deprecated)** List of all existing :class:`Boundary conditions <ansys.simai.core.data.types.BoundaryConditions>`
         instances in the selection.
         """
-        logger.warning(
-            "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead."
+        warnings.warn(
+            "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead.",
+            PySimAIDepreciationWarning,
+            stacklevel=2,
         )
         return self._scalars
 

--- a/src/ansys/simai/core/data/types.py
+++ b/src/ansys/simai/core/data/types.py
@@ -21,9 +21,9 @@
 # SOFTWARE.
 
 import io
-import logging
 import os
 import pathlib
+import warnings
 from contextlib import contextmanager
 from enum import Enum
 from numbers import Number
@@ -47,7 +47,7 @@ from typing import (
 from httpx import Response
 
 from ansys.simai.core.data.base import DataModel, DataModelType, Directory
-from ansys.simai.core.errors import InvalidArguments
+from ansys.simai.core.errors import InvalidArguments, PySimAIDepreciationWarning
 from ansys.simai.core.utils.files import file_path_to_obj_file
 from ansys.simai.core.utils.numerical import (
     is_bigger_or_equal_with_tolerance,
@@ -56,8 +56,6 @@ from ansys.simai.core.utils.numerical import (
     is_smaller_or_equal_with_tolerance,
     validate_tolerance_parameter,
 )
-
-logger = logging.getLogger(__name__)
 
 # DEPRECATED
 BoundaryConditions = Dict[str, Number]
@@ -120,8 +118,10 @@ T_co = TypeVar("T_co", covariant=True)
 
 # DEPRECATED
 def build_boundary_conditions(boundary_conditions: Optional[Dict[str, Number]] = None, **kwargs):
-    logger.warning(
-        "'build_boundary_conditions()' is deprecated and will be removed in a future release. Please use 'build_scalars()' instead."
+    warnings.warn(
+        "'build_boundary_conditions()' is deprecated and will be removed in a future release. Please use 'build_scalars()' instead.",
+        PySimAIDepreciationWarning,
+        stacklevel=2,
     )
     bc = boundary_conditions or {}
     bc.update(**kwargs)
@@ -133,8 +133,10 @@ def build_boundary_conditions(boundary_conditions: Optional[Dict[str, Number]] =
 
 
 def is_boundary_conditions(bc):
-    logger.warning(
-        "'is_boundary_conditions()' is deprecated and will be removed in a future release. Please use 'is_scalars()' instead."
+    warnings.warn(
+        "'is_boundary_conditions()' is deprecated and will be removed in a future release. Please use 'is_scalars()' instead.",
+        PySimAIDepreciationWarning,
+        stacklevel=2,
     )
     return isinstance(bc, dict) and all(is_number(x) for x in bc.values())
 
@@ -144,8 +146,10 @@ def are_boundary_conditions_equal(
     right: BoundaryConditions,
     tolerance: Optional[Number] = None,
 ):
-    logger.warning(
-        "'are_boundary_conditions_equal' is deprecated and will be removed in a future release. Please use 'are_scalars_equal()' instead."
+    warnings.warn(
+        "'are_boundary_conditions_equal' is deprecated and will be removed in a future release. Please use 'are_scalars_equal()' instead.",
+        PySimAIDepreciationWarning,
+        stacklevel=2,
     )
     if not is_boundary_conditions(left):
         raise TypeError(

--- a/src/ansys/simai/core/data/workspaces.py
+++ b/src/ansys/simai/core/data/workspaces.py
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import logging
 import warnings
 from pprint import pformat
 from typing import TYPE_CHECKING, Any, BinaryIO, Dict, List, Optional, Union
@@ -35,13 +34,12 @@ from ansys.simai.core.data.types import (
     get_id_from_identifiable,
     to_raw_filters,
 )
+from ansys.simai.core.errors import PySimAIDepreciationWarning
 from ansys.simai.core.utils.pagination import DataModelIterator
 
 if TYPE_CHECKING:
     from ansys.simai.core.data.geometries import Geometry
     from ansys.simai.core.data.predictions import Prediction
-
-logger = logging.getLogger(__name__)
 
 
 class ModelManifest:
@@ -71,8 +69,10 @@ class ModelManifest:
     @property
     def boundary_conditions(self) -> Dict[str, Any]:
         """**(Deprecated)** Information on the boundary conditions expected by the model. For example, the prediction's input."""
-        logger.warning(
-            "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead."
+        warnings.warn(
+            "'boundary_conditions' is deprecated and will be removed in a future release. Please use 'scalars' instead.",
+            PySimAIDepreciationWarning,
+            stacklevel=2,
         )
         return self._raw["boundary_conditions"]
 
@@ -117,6 +117,7 @@ class Workspace(DataModel):
         """Deprecated alias to :py:attr:`~model_manifest`."""
         warnings.warn(
             "workspace.model is deprecated, please use workspace.model_manifest",
+            PySimAIDepreciationWarning,
             stacklevel=2,
         )
         return self.model_manifest

--- a/src/ansys/simai/core/errors.py
+++ b/src/ansys/simai/core/errors.py
@@ -144,3 +144,7 @@ def _foreach_despite_errors(
         if len(errors) == 1:
             raise errors[0]
         raise MultipleErrors(errors)
+
+
+class PySimAIDepreciationWarning(UserWarning):
+    pass

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -23,6 +23,7 @@
 import pytest
 
 from ansys.simai.core.data.geometries import Geometry
+from ansys.simai.core.errors import PySimAIDepreciationWarning
 
 
 def test_prediction_failure(simai_client):
@@ -176,6 +177,41 @@ def test_run_no_bc(simai_client, geometry_factory, httpx_mock):
     )
     geometry = geometry_factory(id="geom-0")
     simai_client.predictions.run(geometry.id)
+
+
+def test_run_scalars(simai_client, geometry_factory, httpx_mock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://test.test/geometries/geom-0",
+        json={"id": "geom-0"},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://test.test/geometries/geom-0/predictions",
+        json={"id": "pred-0"},
+        status_code=200,
+    )
+    geometry = geometry_factory(id="geom-0")
+    simai_client.predictions.run(geometry.id, scalars={"Vx": 10.5})
+
+
+def test_run_boundary_conditions(simai_client, geometry_factory, httpx_mock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://test.test/geometries/geom-0",
+        json={"id": "geom-0"},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://test.test/geometries/geom-0/predictions",
+        json={"id": "pred-0"},
+        status_code=200,
+    )
+    geometry = geometry_factory(id="geom-0")
+    with pytest.warns(PySimAIDepreciationWarning):
+        simai_client.predictions.run(geometry.id, boundary_conditions={"Vx": 10.5})
 
 
 def test_confidence_score(prediction_factory, httpx_mock):


### PR DESCRIPTION
And improve depreciation warning.
Not using logger because it might not be configured by user. Not using built-in depreciations warnings because those are ignored by default in Python