### PR TITLE
feat: GeomAI prediction auto-resolution

### DIFF
--- a/doc/source/examples/02_generative_design_ex/02-generate_random_geometries.py
+++ b/doc/source/examples/02_generative_design_ex/02-generate_random_geometries.py
@@ -55,7 +55,6 @@ PROJECT_NAME = "new-bracket-project"  # Replace with your project name
 WORKSPACE_NAME = "new-bracket-project #1"  # Typically "{PROJECT_NAME} #{number}"
 OUTPUT_DIR = "random_geometries"  # Directory to save generated geometries
 NUM_GEOMETRIES = 5  # Number of random geometries to generate
-RESOLUTION = (100, 100, 100)  # Output resolution (x, y, z)
 
 ###############################################################################
 # Initialize the client and get the workspace
@@ -107,7 +106,6 @@ for i in range(NUM_GEOMETRIES):
     # Create prediction configuration
     config = GeomAIPredictionConfiguration(
         latent_params=latent_params,
-        resolution=RESOLUTION,
     )
 
     # Run the prediction
@@ -146,7 +144,6 @@ for i, prediction in enumerate(predictions):
 # -------------------------------------------
 #
 # - Latent parameters typically range from -3 to +3 for meaningful results.
-# - Adjust the resolution to balance quality and file size.
 # - Increase timeout for complex geometries.
 # - Use the workspace's latent space statistics (min, max) for better sampling.
 

--- a/doc/source/examples/02_generative_design_ex/02-generate_random_geometries.py
+++ b/doc/source/examples/02_generative_design_ex/02-generate_random_geometries.py
@@ -144,6 +144,7 @@ for i, prediction in enumerate(predictions):
 # -------------------------------------------
 #
 # - Latent parameters typically range from -3 to +3 for meaningful results.
+# - Increasing resolution improves the geometry resolution and helps capture finer details. However, this will also increase the prediction time.
 # - Increase timeout for complex geometries.
 # - Use the workspace's latent space statistics (min, max) for better sampling.
 

--- a/doc/source/examples/02_generative_design_ex/03-interpolate_geometries.py
+++ b/doc/source/examples/02_generative_design_ex/03-interpolate_geometries.py
@@ -62,7 +62,6 @@ PROJECT_NAME = "new-bracket-project"  # Replace with your project name
 WORKSPACE_NAME = "new-bracket-project #1"  # Typically "{PROJECT_NAME} #{number}"
 OUTPUT_DIR = "interpolations"  # Directory to save interpolated geometries
 NUM_STEPS = 10  # Number of interpolation steps
-RESOLUTION = (100, 100, 100)  # Output resolution (x, y, z)
 
 # Choose geometries to interpolate between (by name)
 GEOM_A_NAME = "geometry_name_a"  # Replace with actual geometry name
@@ -155,7 +154,6 @@ for i in range(NUM_STEPS + 1):
     print(f"\nGenerating geometry {i}/{NUM_STEPS} (alpha={alpha:.2f})...")
     config = GeomAIPredictionConfiguration(
         latent_params=latent_params,
-        resolution=RESOLUTION,
     )
     prediction = geomai_client.predictions.run(config, workspace)
     print(f"Prediction {i}: {prediction.id} started...")

--- a/doc/source/user_guide/generative_design_ug/generative_design.rst
+++ b/doc/source/user_guide/generative_design_ug/generative_design.rst
@@ -11,18 +11,3 @@ You define this parameter to generate a geometry with a trained model.
 
 The number of floats must match the ``nb_latent_param`` your model was requested with.
 For more information, see Number of latent parameters.
-
-
-Resolution
------------
-
-The resolution parameter is a list of three integers defining the number of voxels along the X, Y, and Z axes.
-
-Use higher resolution for complex or precise geometries, and lower resolution for simple shapes or quick previews.
-
-The total number of voxels must not exceed 900^3, that is `x`, `y`, `z` multiplied together must be less than or equal to 900^3.
-If you exceed that value, an error occurs.
-
-Defaults to ``[100,100,100]``, if ``None`` is provided.
-
-For the maximum resolution of 900^3, the prediction takes approximately 10 minutes (approximately 1 microsecond per voxel).

--- a/doc/source/user_guide/generative_design_ug/generative_design.rst
+++ b/doc/source/user_guide/generative_design_ug/generative_design.rst
@@ -11,3 +11,27 @@ You define this parameter to generate a geometry with a trained model.
 
 The number of floats must match the ``nb_latent_param`` your model was requested with.
 For more information, see Number of latent parameters.
+
+
+Resolution
+-----------
+
+The resolution parameter corresponds to a list of three integers defining the number of voxels along the X, Y, and Z axes.
+
+By default, this parameter is set automatically based on training data.
+
+How does this auto-resolution system work?
+
+During training, each dataset is assigned a resolution derived from its mesh characteristics, particularly average edge lengths,
+so that reconstructed outputs preserve similar geometric fidelity.
+
+At inference, the system finds the nearest training example in the latent space, and reuses its associated resolution.
+
+As a result, the resolution is not fixed per model but varies per inference, it provides you with
+a data-driven default to ease user experience. You can still adjust it manually by using
+higher resolution for complex or precise geometries, and lower resolution for simple shapes or quick previews.
+
+The total number of voxels must not exceed 900^3, that is x, y, z multiplied together must be less than or equal to 900^3.
+If you exceed that value, an error occurs.
+
+For the maximum resolution of 900^3, the prediction takes approximately 10 minutes (approximately 1 microsecond per voxel).

--- a/src/ansys/simai/core/api/geomai/predictions.py
+++ b/src/ansys/simai/core/api/geomai/predictions.py
@@ -63,7 +63,7 @@ class GeomAIPredictionClientMixin(ApiClientMixin):
     def run_geomai_sampling(
         self, workspace_id: str, resolution: Optional[Tuple[PositiveInt, PositiveInt, PositiveInt]]
     ):
-        payload = {"resolution": resolution} if resolution is not None else {}
+        payload = {"resolution": resolution}
         return self._post(f"geomai/workspaces/{workspace_id}/predictions/sample", json=payload)
 
     def download_geomai_prediction(self, prediction_id: str, file: Optional[File]):

--- a/src/ansys/simai/core/data/geomai/predictions.py
+++ b/src/ansys/simai/core/data/geomai/predictions.py
@@ -49,17 +49,12 @@ class GeomAIPredictionConfiguration(BaseModel):
     Required.
     """
     resolution: Optional[Tuple[PositiveInt, PositiveInt, PositiveInt]] = None
-    """A list of three integers defining the number of voxels along the X, Y, and Z axes.
+    """Auto‑resolution is a system-driven feature that automatically selects the most appropriate reconstruction resolution at inference time based on training data.
 
-    Use higher resolution for complex or precise geometries, and lower resolution for simple shapes or quick previews.
+    During training, each dataset is assigned a resolution derived from its mesh characteristics, particularly average edge lengths, so that reconstructed outputs preserve similar geometric fidelity.
+    At inference, the system projects the input into latent space, finds the nearest training example, and reuses its associated resolution.
 
-    The total number of voxels must not exceed 900^3, that is `x`, `y`, `z` multiplied together must be less than or equal to 900^3.
-    If you exceed that value, an error will occur.
-
-    Defaults to ``[100,100,100]``, if ``None`` is provided.
-
-    For the maximum resolution of 900^3, the prediction takes approximately 10 minutes (approximately 1 microsecond per voxel).
-    """
+    As a result, the resolution is not fixed per model but varies per inference, offering a data-driven default that improves quality while remaining editable by the user. """
 
     def __init__(self, *args, **kwargs):
         """Raises :exc:`~ansys.simai.core.errors.InvalidArguments` if the input data cannot be validated to from a valid model."""
@@ -182,7 +177,7 @@ class GeomAIPredictionDirectory(Directory[GeomAIPrediction]):
                 simai_client = asc.from_config()
                 workspace = simai_client.geomai.workspaces.list()[0]
                 prediction = simai_client.geomai.predictions.run(
-                    dict(latent_params=[0.1, 1.2, 0.76], resolution=(100, 100, 100)),
+                    dict(latent_params=[0.1, 1.2, 0.76]),
                     workspace,
                 )
 

--- a/src/ansys/simai/core/data/geomai/predictions.py
+++ b/src/ansys/simai/core/data/geomai/predictions.py
@@ -211,7 +211,7 @@ class GeomAIPredictionDirectory(Directory[GeomAIPrediction]):
             Testing and feedback are encouraged, but it is advised not to include it in a production workflow.
 
         Args:
-            resolution: Optional resolution used for sampling.
+            resolution: Optional resolution used for sampling, if None the resolution will be set automatically based on the closest training sample.
             workspace: Optional ID or :class:`model <.workspaces.GeomAIWorkspace>` of the target workspace.
                 Defaults to the current workspace if set.
 

--- a/src/ansys/simai/core/data/geomai/predictions.py
+++ b/src/ansys/simai/core/data/geomai/predictions.py
@@ -49,12 +49,15 @@ class GeomAIPredictionConfiguration(BaseModel):
     Required.
     """
     resolution: Optional[Tuple[PositiveInt, PositiveInt, PositiveInt]] = None
-    """Auto‑resolution is a system-driven feature that automatically selects the most appropriate reconstruction resolution at inference time based on training data.
+    """By default, this parameter is set automatically based on available training data. For more information, see (link to section Resolution in the User guide).
 
-    During training, each dataset is assigned a resolution derived from its mesh characteristics, particularly average edge lengths, so that reconstructed outputs preserve similar geometric fidelity.
-    At inference, the system projects the input into latent space, finds the nearest training example, and reuses its associated resolution.
+    If you need to adjust it manually, use a list of three integers defining the number of voxels along the X, Y, and Z axes: higher resolution for complex or precise geometries, and lower resolution for simple shapes or quick previews.
 
-    As a result, the resolution is not fixed per model but varies per inference, offering a data-driven default that improves quality while remaining editable by the user. """
+    The total number of voxels must not exceed 900^3, that is `x`, `y`, `z` multiplied together must be less than or equal to 900^3.
+    If you exceed that value, an error will occur.
+
+    For the maximum resolution of 900^3, the prediction takes approximately 10 minutes (approximately 1 microsecond per voxel).
+    """
 
     def __init__(self, *args, **kwargs):
         """Raises :exc:`~ansys.simai.core.errors.InvalidArguments` if the input data cannot be validated to from a valid model."""


### PR DESCRIPTION
Add auto-resolution to GeomAI prediction, setting a resolution is not mandatory and the default value will be automatically selected.

Do not merge until user-api has not been merged.

[sc-38644]
[sc-38520]