### PR TITLE
chore(auth): use namespaced OIDC client id

### DIFF
--- a/src/ansys/simai/core/utils/auth.py
+++ b/src/ansys/simai/core/utils/auth.py
@@ -43,7 +43,7 @@ from ansys.simai.core.utils.requests import handle_response
 
 logger = logging.getLogger(__name__)
 
-OIDC_CLIENT_ID = "com.ansys.simai.sdk"
+OIDC_CLIENT_ID = "44a6fc38-d3ac-4e10-b379-9245db066388"
 # polling can't be faster or auth server returns HTTP 400 Slow down
 DEVICE_AUTH_POLLING_INTERVAL = 5
 # Try to refresh tokens 300-400 secs before they go bad

--- a/src/ansys/simai/core/utils/auth.py
+++ b/src/ansys/simai/core/utils/auth.py
@@ -43,6 +43,7 @@ from ansys.simai.core.utils.requests import handle_response
 
 logger = logging.getLogger(__name__)
 
+OIDC_CLIENT_ID = "com.ansys.simai.sdk"
 # polling can't be faster or auth server returns HTTP 400 Slow down
 DEVICE_AUTH_POLLING_INTERVAL = 5
 # Try to refresh tokens 300-400 secs before they go bad
@@ -110,7 +111,7 @@ def _request_tokens_direct_grant(
     """Request tokens via username/password (direct grant)."""
     logger.debug(f"request authentication tokens via direct grant (scope={scope})")
     request_params = {
-        "client_id": "com.ansys.simai.sdk",
+        "client_id": OIDC_CLIENT_ID,
         "grant_type": "password",
         "scope": scope,
         **credentials.model_dump(),
@@ -127,7 +128,7 @@ def _request_tokens_device_auth(
     """Request tokens via device auth flow (browser-based)."""
     logger.debug(f"request authentication tokens via device auth (scope={scope})")
     auth_codes = handle_response(
-        session.post(device_auth_url, data={"client_id": "com.ansys.simai.sdk", "scope": scope})
+        session.post(device_auth_url, data={"client_id": OIDC_CLIENT_ID, "scope": scope})
     )
     print(  # noqa: T201
         f"Go to {auth_codes['verification_uri']} and enter the code {auth_codes['user_code']}"
@@ -140,7 +141,7 @@ def _request_tokens_device_auth(
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             data={
                 "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-                "client_id": "com.ansys.simai.sdk",
+                "client_id": OIDC_CLIENT_ID,
                 "device_code": auth_codes["device_code"],
             },
         )
@@ -190,7 +191,7 @@ class _AuthTokensRetriever:
     def _refresh_auth_tokens(self, refresh_token: str) -> Optional[_AuthTokens]:
         logger.debug("Refreshing authentication tokens.")
         request_params = {
-            "client_id": "com.ansys.simai.sdk",
+            "client_id": OIDC_CLIENT_ID,
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
         }

--- a/src/ansys/simai/core/utils/auth.py
+++ b/src/ansys/simai/core/utils/auth.py
@@ -110,7 +110,7 @@ def _request_tokens_direct_grant(
     """Request tokens via username/password (direct grant)."""
     logger.debug(f"request authentication tokens via direct grant (scope={scope})")
     request_params = {
-        "client_id": "sdk",
+        "client_id": "com.ansys.simai.sdk",
         "grant_type": "password",
         "scope": scope,
         **credentials.model_dump(),
@@ -127,7 +127,7 @@ def _request_tokens_device_auth(
     """Request tokens via device auth flow (browser-based)."""
     logger.debug(f"request authentication tokens via device auth (scope={scope})")
     auth_codes = handle_response(
-        session.post(device_auth_url, data={"client_id": "sdk", "scope": scope})
+        session.post(device_auth_url, data={"client_id": "com.ansys.simai.sdk", "scope": scope})
     )
     print(  # noqa: T201
         f"Go to {auth_codes['verification_uri']} and enter the code {auth_codes['user_code']}"
@@ -140,7 +140,7 @@ def _request_tokens_device_auth(
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             data={
                 "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-                "client_id": "sdk",
+                "client_id": "com.ansys.simai.sdk",
                 "device_code": auth_codes["device_code"],
             },
         )
@@ -190,7 +190,7 @@ class _AuthTokensRetriever:
     def _refresh_auth_tokens(self, refresh_token: str) -> Optional[_AuthTokens]:
         logger.debug("Refreshing authentication tokens.")
         request_params = {
-            "client_id": "sdk",
+            "client_id": "com.ansys.simai.sdk",
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
         }

--- a/src/ansys/simai/core/utils/auth.py
+++ b/src/ansys/simai/core/utils/auth.py
@@ -43,7 +43,7 @@ from ansys.simai.core.utils.requests import handle_response
 
 logger = logging.getLogger(__name__)
 
-OIDC_CLIENT_ID = "44a6fc38-d3ac-4e10-b379-9245db066388"
+OIDC_CLIENT_ID = "com.ansys.simai.sdk"
 # polling can't be faster or auth server returns HTTP 400 Slow down
 DEVICE_AUTH_POLLING_INTERVAL = 5
 # Try to refresh tokens 300-400 secs before they go bad


### PR DESCRIPTION
Update the OIDC client_id to use the new namespaced one, for example this allows an operator to deploy `com.ansys.simai.sdk` alongside `com.ansys.fluent.sdk` (invented name).

This requires the internal infra change first.

The legacy `client_id: sdk` will keep working for a year from now. 