### PR TITLE
fix: refresh token with same client id

### DIFF
--- a/src/ansys/simai/core/utils/auth.py
+++ b/src/ansys/simai/core/utils/auth.py
@@ -201,6 +201,8 @@ class _AuthTokensRetriever:
 
     def _refresh_auth_tokens(self, refresh_token: str) -> Optional[_AuthTokens]:
         logger.debug("Refreshing authentication tokens.")
+        # temporary fix for refresh while we still have legacy
+        # client_id == "sdk" tokens around
         requested_client_id = (
             "sdk" if _decode_authorized_party(refresh_token) == "sdk" else OIDC_CLIENT_ID
         )

--- a/src/ansys/simai/core/utils/auth.py
+++ b/src/ansys/simai/core/utils/auth.py
@@ -201,7 +201,7 @@ class _AuthTokensRetriever:
 
     def _refresh_auth_tokens(self, refresh_token: str) -> Optional[_AuthTokens]:
         logger.debug("Refreshing authentication tokens.")
-        # temporary fix for refresh while we still have legacy
+        # TODO: temporary fix for refresh while we still have legacy
         # client_id == "sdk" tokens around
         requested_client_id = (
             "sdk" if _decode_authorized_party(refresh_token) == "sdk" else OIDC_CLIENT_ID

--- a/src/ansys/simai/core/utils/auth.py
+++ b/src/ansys/simai/core/utils/auth.py
@@ -64,6 +64,17 @@ def _decode_user_uuid(access_token: str) -> Optional[str]:
     return claims.get("sub") or claims.get("user_uuid") or claims.get("uuid")
 
 
+def _decode_authorized_party(access_token: str) -> Optional[str]:
+    try:
+        claims = jwt.decode(
+            access_token,
+            options={"verify_signature": False},
+        )
+    except jwt.PyJWTError:
+        return None
+    return claims.get("azp")
+
+
 class _AuthTokens(BaseModel):
     """Represents the OIDC tokens received from the auth server."""
 
@@ -190,8 +201,11 @@ class _AuthTokensRetriever:
 
     def _refresh_auth_tokens(self, refresh_token: str) -> Optional[_AuthTokens]:
         logger.debug("Refreshing authentication tokens.")
+        requested_client_id = (
+            "sdk" if _decode_authorized_party(refresh_token) == "sdk" else OIDC_CLIENT_ID
+        )
         request_params = {
-            "client_id": OIDC_CLIENT_ID,
+            "client_id": requested_client_id,
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
         }

--- a/tests/utils/test_auth.py
+++ b/tests/utils/test_auth.py
@@ -37,6 +37,7 @@ from ansys.simai.core.utils.auth import (
     Authenticator,
     _AuthTokens,
     _AuthTokensRetriever,
+    _decode_authorized_party,
 )
 from ansys.simai.core.utils.configuration import ClientConfig, Credentials
 
@@ -418,3 +419,20 @@ def test_non_interactive_mode_accepts_offline_token():
     )
     assert config.offline_token == "my-offline-token"
     assert config.credentials is None
+
+
+@pytest.mark.parametrize(
+    ("token", "expected_authorized_party"),
+    [
+        (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYXpwIjoic2RrIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.amyval0O_iUVxQNx1HbVbzpiIA4LWuMt_JhTLL4n84g",
+            "sdk",
+        ),
+        (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYXpwIjoiY29tLmFuc3lzLnNpbWFpLnNkayIsImFkbWluIjp0cnVlLCJpYXQiOjE1MTYyMzkwMjJ9.TTDEBC6B6bfLDaF4huBrFnub2UAqw7CGsiWB3tawKs8",
+            "com.ansys.simai.sdk",
+        ),
+    ],
+)
+def test__decode_authorized_party(token, expected_authorized_party):
+    assert _decode_authorized_party(token) == expected_authorized_party


### PR DESCRIPTION
if refresh token has azp still in legacy "sdk", request a new token with the same "sdk" client_id (else the backend will reject it)

Doesn't touch new token requests which will request "com.ansys.simai.sdk".

[sc-new-story]