### PR TITLE
feat: handle remote protocol error in SSE stream

### DIFF
--- a/src/ansys/simai/core/api/sse.py
+++ b/src/ansys/simai/core/api/sse.py
@@ -97,6 +97,8 @@ class SSEMixin(ApiClientMixin):
                                 return
                 except httpx.ReadError as e:
                     logger.info(f"SSE disconnection: {e}")
+                except httpx.RemoteProtocolError as e:
+                    logger.info(f"SSE connection lost (incomplete response): {e}")
                 except httpx.HTTPError as e:
                     if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 403:
                         raise ConnectionError(e.response.text) from e


### PR DESCRIPTION
Handle incomplete response error in SSE stream in order to try a reconnection when it happens instead of raising an error.

[sc-38290]