### PR TITLE
fix: for server side optim, request a token matching the coreml versi…

### DIFF
--- a/src/ansys/simai/core/data/optimizations.py
+++ b/src/ansys/simai/core/data/optimizations.py
@@ -24,9 +24,16 @@ import logging
 import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Union
+import re
 
 from tqdm import tqdm
+from ansys.simai.core.utils.auth import (
+    _get_offline_token_private,
+    OIDC_CLIENT_ID,
+    _decode_authorized_party,
+)
 from wakepy import keep
+from itertools import chain
 
 from ansys.simai.core.data.base import ComputableDataModel, Directory
 from ansys.simai.core.data.geometries import Geometry
@@ -334,9 +341,13 @@ class OptimizationDirectory(Directory[Optimization]):
         )
         use_server_side_optimization = False
         workspace_id = actual_geometry._fields["workspace_id"]
+        coreml_version: str | None = None
+        manifest = {}
         try:
             manifest = self._client._api.get_workspace_model_manifest(workspace_id)
             if "server_side_optimization" in manifest.get("feature_flags", []):
+                use_server_side_optimization = True
+            if "coreml_version" in manifest.get("coreml_version", []):
                 use_server_side_optimization = True
         except NotFoundError:
             warnings.warn(f"Could not find workspace '{workspace_id}'", stacklevel=1)
@@ -348,6 +359,23 @@ class OptimizationDirectory(Directory[Optimization]):
                 raise InvalidArguments(
                     "No offline_token specified as argument or client configuration"
                 )
+
+            if coreml_version := manifest.get("coreml_version", None):
+                expected_client_id = _get_expected_client_id_for_coreml_model(coreml_version)
+                if expected_client_id is not None:
+                    current_client_id = _decode_authorized_party(offline_token)
+
+                    if expected_client_id != current_client_id:
+                        logger.warning(f"Provided offline token for optimization has client_id == '{current_client_id}', while model named '{manifest.get("model_name", "")}' only works with client_id == '{expected_client_id}' . Requesting a new token with client_id == '{expected_client_id}'")
+
+                        client_config = self._client._config
+                        offline_token = _get_offline_token_private(
+                            url=str(client_config.url),
+                            credentials=client_config.credentials,
+                            https_proxy=str(client_config.https_proxy) if client_config.https_proxy else None,
+                            tls_ca_bundle=str(client_config.tls_ca_bundle) if client_config.tls_ca_bundle else None,
+                            client_id=expected_client_id
+                    )
 
             if not max_displacement:
                 raise InvalidArguments("max_displacement must be provided")
@@ -790,3 +818,27 @@ def _build_objective(minimize: list[str], maximize: list[str]) -> dict:
         for global_coefficient in maximize:
             objective[global_coefficient] = {"minimize": False}
     return objective
+
+def _get_expected_client_id_for_coreml_model(coreml_version: str) -> Union[str, None]:
+    """Returns which client_id you have to use to interact with this model's coreml version
+    str : you have to use this specific client_id to interact with this model's coreml version
+    None : the model either tolerates both, the client_id could not be determined or the coreml version is so old that it doesn't need an offline token from the user."""
+    if re.fullmatch(r"\d+\.\d+\.\d+", coreml_version):
+        major, minor, _ = coreml_version.split('.')
+        major, minor = int(major), int(minor)
+        if major <= 2:
+            return None
+        if major == 3:
+            if minor == 16 or minor == 17:
+                return "sdk"
+            elif minor < 16:
+                return None
+            else:
+                # TODO : update when coreml can start supporting both
+                return OIDC_CLIENT_ID
+        if major > 3:
+            # TODO : update when coreml can start supporting both
+            return OIDC_CLIENT_ID
+    else:
+        return None
+

--- a/src/ansys/simai/core/data/optimizations.py
+++ b/src/ansys/simai/core/data/optimizations.py
@@ -21,19 +21,13 @@
 # SOFTWARE.
 
 import logging
+import re
 import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Union
-import re
 
 from tqdm import tqdm
-from ansys.simai.core.utils.auth import (
-    _get_offline_token_private,
-    OIDC_CLIENT_ID,
-    _decode_authorized_party,
-)
 from wakepy import keep
-from itertools import chain
 
 from ansys.simai.core.data.base import ComputableDataModel, Directory
 from ansys.simai.core.data.geometries import Geometry
@@ -43,6 +37,11 @@ from ansys.simai.core.data.types import (
     get_object_from_identifiable,
 )
 from ansys.simai.core.errors import InvalidArguments, NotFoundError, PySimAIDepreciationWarning
+from ansys.simai.core.utils.auth import (
+    OIDC_CLIENT_ID,
+    _decode_authorized_party,
+    _get_offline_token_private,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -366,16 +365,22 @@ class OptimizationDirectory(Directory[Optimization]):
                     current_client_id = _decode_authorized_party(offline_token)
 
                     if expected_client_id != current_client_id:
-                        logger.warning(f"Provided offline token for optimization has client_id == '{current_client_id}', while model named '{manifest.get("model_name", "")}' only works with client_id == '{expected_client_id}' . Requesting a new token with client_id == '{expected_client_id}'")
+                        logger.warning(
+                            f"Provided offline token for optimization has client_id == '{current_client_id}', while model named '{manifest.get('model_name', '')}' only works with client_id == '{expected_client_id}' . Requesting a new token with client_id == '{expected_client_id}'"
+                        )
 
                         client_config = self._client._config
                         offline_token = _get_offline_token_private(
                             url=str(client_config.url),
                             credentials=client_config.credentials,
-                            https_proxy=str(client_config.https_proxy) if client_config.https_proxy else None,
-                            tls_ca_bundle=str(client_config.tls_ca_bundle) if client_config.tls_ca_bundle else None,
-                            client_id=expected_client_id
-                    )
+                            https_proxy=str(client_config.https_proxy)
+                            if client_config.https_proxy
+                            else None,
+                            tls_ca_bundle=str(client_config.tls_ca_bundle)
+                            if client_config.tls_ca_bundle
+                            else None,
+                            client_id=expected_client_id,
+                        )
 
             if not max_displacement:
                 raise InvalidArguments("max_displacement must be provided")
@@ -819,12 +824,14 @@ def _build_objective(minimize: list[str], maximize: list[str]) -> dict:
             objective[global_coefficient] = {"minimize": False}
     return objective
 
+
 def _get_expected_client_id_for_coreml_model(coreml_version: str) -> Union[str, None]:
     """Returns which client_id you have to use to interact with this model's coreml version
     str : you have to use this specific client_id to interact with this model's coreml version
-    None : the model either tolerates both, the client_id could not be determined or the coreml version is so old that it doesn't need an offline token from the user."""
+    None : the model either tolerates both, the client_id could not be determined or the coreml version is so old that it doesn't need an offline token from the user.
+    """
     if re.fullmatch(r"\d+\.\d+\.\d+", coreml_version):
-        major, minor, _ = coreml_version.split('.')
+        major, minor, _ = coreml_version.split(".")
         major, minor = int(major), int(minor)
         if major <= 2:
             return None
@@ -841,4 +848,3 @@ def _get_expected_client_id_for_coreml_model(coreml_version: str) -> Union[str, 
             return OIDC_CLIENT_ID
     else:
         return None
-

--- a/src/ansys/simai/core/data/optimizations.py
+++ b/src/ansys/simai/core/data/optimizations.py
@@ -340,7 +340,7 @@ class OptimizationDirectory(Directory[Optimization]):
         )
         use_server_side_optimization = False
         workspace_id = actual_geometry._fields["workspace_id"]
-        coreml_version: str | None = None
+        coreml_version: Optional[str] = None
         manifest = {}
         try:
             manifest = self._client._api.get_workspace_model_manifest(workspace_id)

--- a/src/ansys/simai/core/data/optimizations.py
+++ b/src/ansys/simai/core/data/optimizations.py
@@ -847,7 +847,6 @@ def _get_expected_client_id_for_coreml_model(coreml_version: str) -> Union[str, 
             else:
                 return None
         if major > 3:
-            # TODO : update when coreml can start supporting both
             return None
     else:
         return None

--- a/src/ansys/simai/core/data/optimizations.py
+++ b/src/ansys/simai/core/data/optimizations.py
@@ -836,15 +836,18 @@ def _get_expected_client_id_for_coreml_model(coreml_version: str) -> Union[str, 
         if major <= 2:
             return None
         if major == 3:
-            if minor == 16 or minor == 17:
-                return "sdk"
-            elif minor < 16:
+            # model doesn't support server side optim so client_id is irrelevant
+            if minor < 16:
                 return None
-            else:
-                # TODO : update when coreml can start supporting both
+            elif minor == 16 or minor == 17:
+                return "sdk"
+            elif minor <= 19:
                 return OIDC_CLIENT_ID
+            # from 3.20 onwards : both are supported
+            else:
+                return None
         if major > 3:
             # TODO : update when coreml can start supporting both
-            return OIDC_CLIENT_ID
+            return None
     else:
         return None

--- a/src/ansys/simai/core/utils/auth.py
+++ b/src/ansys/simai/core/utils/auth.py
@@ -118,11 +118,12 @@ def _request_tokens_direct_grant(
     token_url: str,
     credentials: Credentials,
     scope: str = "openid",
+    client_id: str | None = OIDC_CLIENT_ID,
 ) -> _AuthTokens:
     """Request tokens via username/password (direct grant)."""
     logger.debug(f"request authentication tokens via direct grant (scope={scope})")
     request_params = {
-        "client_id": OIDC_CLIENT_ID,
+        "client_id": client_id or OIDC_CLIENT_ID,
         "grant_type": "password",
         "scope": scope,
         **credentials.model_dump(),
@@ -135,11 +136,13 @@ def _request_tokens_device_auth(
     token_url: str,
     device_auth_url: str,
     scope: str = "openid",
+    client_id: str | None = OIDC_CLIENT_ID,
 ) -> _AuthTokens:
     """Request tokens via device auth flow (browser-based)."""
     logger.debug(f"request authentication tokens via device auth (scope={scope})")
+    client_id = client_id or OIDC_CLIENT_ID
     auth_codes = handle_response(
-        session.post(device_auth_url, data={"client_id": OIDC_CLIENT_ID, "scope": scope})
+        session.post(device_auth_url, data={"client_id": client_id, "scope": scope})
     )
     print(  # noqa: T201
         f"Go to {auth_codes['verification_uri']} and enter the code {auth_codes['user_code']}"
@@ -152,7 +155,7 @@ def _request_tokens_device_auth(
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             data={
                 "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-                "client_id": OIDC_CLIENT_ID,
+                "client_id": client_id,
                 "device_code": auth_codes["device_code"],
             },
         )
@@ -281,6 +284,22 @@ def get_offline_token(
     Returns:
         The offline token (a refresh_token that does not expire with sessions)
     """
+    return _get_offline_token_private(
+        url=url,
+        credentials=credentials,
+        https_proxy=https_proxy,
+        tls_ca_bundle=tls_ca_bundle,
+        client_id=OIDC_CLIENT_ID
+    )
+
+
+def _get_offline_token_private(
+    url: str,
+    credentials: Optional[Credentials] = None,
+    https_proxy: Optional[str] = None,
+    tls_ca_bundle: Optional[str] = None,
+    client_id: Optional[str] = None
+) -> str:
     realm_url = urljoin(url.rstrip("/") + "/", "/auth/realms/simai")
     token_url = f"{realm_url}/protocol/openid-connect/token"
     device_auth_url = f"{realm_url}/protocol/openid-connect/auth/device"
@@ -294,11 +313,11 @@ def get_offline_token(
     with httpx.Client(**transport_kwargs) as session:
         if credentials:
             tokens = _request_tokens_direct_grant(
-                session, token_url, credentials, scope="openid offline_access"
+                session, token_url, credentials, scope="openid offline_access", client_id=client_id
             )
         else:
             tokens = _request_tokens_device_auth(
-                session, token_url, device_auth_url, scope="openid offline_access"
+                session, token_url, device_auth_url, scope="openid offline_access", client_id=client_id
             )
         return tokens.refresh_token
 

--- a/src/ansys/simai/core/utils/auth.py
+++ b/src/ansys/simai/core/utils/auth.py
@@ -118,7 +118,7 @@ def _request_tokens_direct_grant(
     token_url: str,
     credentials: Credentials,
     scope: str = "openid",
-    client_id: str | None = OIDC_CLIENT_ID,
+    client_id: Optional[str] = OIDC_CLIENT_ID,
 ) -> _AuthTokens:
     """Request tokens via username/password (direct grant)."""
     logger.debug(f"request authentication tokens via direct grant (scope={scope})")
@@ -136,7 +136,7 @@ def _request_tokens_device_auth(
     token_url: str,
     device_auth_url: str,
     scope: str = "openid",
-    client_id: str | None = OIDC_CLIENT_ID,
+    client_id: Optional[str] = OIDC_CLIENT_ID,
 ) -> _AuthTokens:
     """Request tokens via device auth flow (browser-based)."""
     logger.debug(f"request authentication tokens via device auth (scope={scope})")

--- a/src/ansys/simai/core/utils/auth.py
+++ b/src/ansys/simai/core/utils/auth.py
@@ -289,7 +289,7 @@ def get_offline_token(
         credentials=credentials,
         https_proxy=https_proxy,
         tls_ca_bundle=tls_ca_bundle,
-        client_id=OIDC_CLIENT_ID
+        client_id=OIDC_CLIENT_ID,
     )
 
 
@@ -298,7 +298,7 @@ def _get_offline_token_private(
     credentials: Optional[Credentials] = None,
     https_proxy: Optional[str] = None,
     tls_ca_bundle: Optional[str] = None,
-    client_id: Optional[str] = None
+    client_id: Optional[str] = None,
 ) -> str:
     realm_url = urljoin(url.rstrip("/") + "/", "/auth/realms/simai")
     token_url = f"{realm_url}/protocol/openid-connect/token"
@@ -317,7 +317,11 @@ def _get_offline_token_private(
             )
         else:
             tokens = _request_tokens_device_auth(
-                session, token_url, device_auth_url, scope="openid offline_access", client_id=client_id
+                session,
+                token_url,
+                device_auth_url,
+                scope="openid offline_access",
+                client_id=client_id,
             )
         return tokens.refresh_token
 

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -36,6 +36,7 @@ from ansys.simai.core.data.optimizations import (
     _validate_max_displacement,
     _validate_n_iters,
     _validate_outcome_constraints,
+    _get_expected_client_id_for_coreml_model,
 )
 from ansys.simai.core.errors import InvalidArguments
 
@@ -443,3 +444,21 @@ def test_run_non_parametric_optimization(simai_client, geometry_factory, model_f
     )
     assert result.is_ready
     assert result.iteration_results == iteration_results
+
+@pytest.mark.parametrize(
+    "coreml_version, expected_result",
+    [
+        ("2.13.4", None),
+        ("3.16.0", "sdk"),
+        ("3.16.3", "sdk"),
+        ("3.16.1", "sdk"),
+        ("3.17.0", "sdk"),
+        ("3.17.2", "sdk"),
+        ("prod-blabla-truc", None),
+        ("3.18.0", "com.ansys.simai.sdk"),
+        ("3.18.2", "com.ansys.simai.sdk"),
+    ],
+)
+def test_get_expected_client_id_for_coreml_model(coreml_version, expected_result):
+    assert _get_expected_client_id_for_coreml_model(coreml_version) == expected_result
+

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -30,13 +30,13 @@ from httpx_sse import ServerSentEvent
 from ansys.simai.core.data.optimizations import (
     LegacyOptimizationResult,
     Optimization,
+    _get_expected_client_id_for_coreml_model,
     _validate_axial_symmetry,
     _validate_bounding_boxes,
     _validate_global_coefficients_for_non_parametric,
     _validate_max_displacement,
     _validate_n_iters,
     _validate_outcome_constraints,
-    _get_expected_client_id_for_coreml_model,
 )
 from ansys.simai.core.errors import InvalidArguments
 
@@ -445,6 +445,7 @@ def test_run_non_parametric_optimization(simai_client, geometry_factory, model_f
     assert result.is_ready
     assert result.iteration_results == iteration_results
 
+
 @pytest.mark.parametrize(
     "coreml_version, expected_result",
     [
@@ -461,4 +462,3 @@ def test_run_non_parametric_optimization(simai_client, geometry_factory, model_f
 )
 def test_get_expected_client_id_for_coreml_model(coreml_version, expected_result):
     assert _get_expected_client_id_for_coreml_model(coreml_version) == expected_result
-

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -458,6 +458,10 @@ def test_run_non_parametric_optimization(simai_client, geometry_factory, model_f
         ("prod-blabla-truc", None),
         ("3.18.0", "com.ansys.simai.sdk"),
         ("3.18.2", "com.ansys.simai.sdk"),
+        ("3.19.2", "com.ansys.simai.sdk"),
+        ("3.20.0", None),
+        ("3.20.1", None),
+        ("4.1.2", None),
     ],
 )
 def test_get_expected_client_id_for_coreml_model(coreml_version, expected_result):


### PR DESCRIPTION
For a server side optim, if coreml_version belongs to  [3.16.0, 3.18.0 [, the used offline_token must be of client_id == "sdk", and if coreml_version is over or equal to 3.18.0, the token's client id must be "com.ansys.simai.sdk". **Update** : 3.20.0 and upwards can support both.

This PR aims to, if it detects a mismatch client_id between the provided offline_token and what the model expects, print a warning and ask the server for a new token matching what the model expects.

Cases like this should be quite rare.

