### PR TITLE
docs: Put the explainer in a box to better organize the section

### DIFF
--- a/doc/source/user_guide/generative_design_ug/generative_design.rst
+++ b/doc/source/user_guide/generative_design_ug/generative_design.rst
@@ -20,20 +20,22 @@ Resolution
 
 The resolution parameter corresponds to a list of three integers defining the number of voxels along the X, Y, and Z axes.
 
-By default, this parameter is set automatically based on training data.
+The total number of voxels must not exceed 900^3 (that is, X × Y × Z ≤ 900^3). Exceeding this limit will result in an error.
 
-How does this auto-resolution system work?
+Prediction time increases with the number of voxels. For the maximum resolution of 900^3, the prediction takes approximately 10 minutes (approximately 1 microsecond per voxel).
 
-During training, each dataset is assigned a resolution derived from its mesh characteristics, particularly average edge lengths,
-so that reconstructed outputs preserve similar geometric fidelity.
+By default, this parameter is set automatically based on the training data used to build the model.
 
-At inference, the system finds the nearest training example in the latent space, and reuses its associated resolution.
+.. admonition::  How does the default auto-resolution system work?
 
-As a result, the resolution is not fixed per model but varies per inference, it provides you with
-a data-driven default to ease user experience. You can still adjust it manually by using
-higher resolution for complex or precise geometries, and lower resolution for simple shapes or quick previews.
+    During training, each dataset is assigned a resolution derived from its mesh characteristics, particularly average edge lengths,
+    so that reconstructed outputs preserve similar geometric fidelity.
 
-The total number of voxels must not exceed 900^3 (that is, X × Y × Z ≤ 900^3).
-Exceeding this limit will result in an error.
+    At inference, the system finds the nearest training example in the latent space, and reuses its associated resolution.
 
-For the maximum resolution of 900^3, the prediction takes approximately 10 minutes (approximately 1 microsecond per voxel).
+    As a result, the resolution is not fixed per model but varies per inference, it provides you with
+    a data-driven default to ease user experience. You can still adjust it manually by using
+    higher resolution for complex or precise geometries, and lower resolution for simple shapes or quick previews.
+
+
+


### PR DESCRIPTION
In this PR, I suggest to refactor the Resolution section in Generative Design doc to isolate the "how does auto resolution work" 

Before:
<img width="894" height="467" alt="image" src="https://github.com/user-attachments/assets/058307b2-9a70-4d93-b8d3-cd23defa4e34" />

After:
<img width="911" height="507" alt="image" src="https://github.com/user-attachments/assets/bdfdafc7-3bc5-4fa5-b6c4-3254f7bd12df" />
