### PR TITLE
feat(geomai): remove the nb_epochs upper limit and document runtime capping

### DIFF
--- a/doc/source/user_guide/generative_design_ug/model_config_and_training.rst
+++ b/doc/source/user_guide/generative_design_ug/model_config_and_training.rst
@@ -26,8 +26,11 @@ For large datasets or geometries with high polygon count, use longer presets (``
 Number of epochs
 ^^^^^^^^^^^^^^^^
 
-You can also configure the number of training iterations for building your model through the ``nb_epochs`` parameter.
-``nb_epochs`` corresponds to the number of times each training data is seen by the model during the training, between 1 and 1000.
+You can also configure the number of training iterations used to build your model through the ``nb_epochs`` parameter.
+``nb_epochs`` represents the number of times the model processes the entire training dataset during training.
+A minimum of 1 epoch is required.
+To ensure training remains within the maximum allowed duration, the requested epoch count may be automatically capped.
+As a result, the actual number of epochs used during training may be lower than the value specified.
 
 ``nb_epochs`` should only be used by expert users.
 While it enables finer customization, it requires prior knowledge on the model's performance.

--- a/src/ansys/simai/core/data/geomai/models.py
+++ b/src/ansys/simai/core/data/geomai/models.py
@@ -64,9 +64,14 @@ class GeomAIModelConfiguration(BaseModel):
 
     Mutually exclusive with ``nb_epochs``.
     """
-    nb_epochs: Optional[int] = Field(default=None, ge=1, le=1000)
+    nb_epochs: Optional[int] = Field(default=None, ge=1)
     """
-    The number of times each training data is seen by the model during the training, between 1 and 1000.
+    The number of times the model processes the training dataset during training.
+    A minimum of 1 epoch is required.
+
+    To keep training within the maximum allowed duration, the system may automatically
+    reduce the requested epoch count. Consequently, the actual number of epochs used may
+    be lower than the configured value.
 
     Mutually exclusive with ``build_preset``.
     """


### PR DESCRIPTION
The hardcoded 1000 epochs limit is being removed from the API, so users can submit any `nb_epochs` value. This PR updates the SDK accordingly and documents the new behavior.