### PR TITLE
fix: `get_last_workspace()` for GeomAI project

### DIFF
--- a/src/ansys/simai/core/api/geomai/projects.py
+++ b/src/ansys/simai/core/api/geomai/projects.py
@@ -87,7 +87,7 @@ class GeomAIProjectClientMixin(ApiClientMixin):
                 (
                     "filter[]",
                     json.dumps(
-                        {"field": "project", "operator": "EQ", "value": project_id},
+                        {"field": "project_id", "operator": "EQ", "value": project_id},
                         separators=(",", ":"),
                     ),
                 ),

--- a/tests/geomai/test_geomai_projects.py
+++ b/tests/geomai/test_geomai_projects.py
@@ -289,7 +289,7 @@ def test_geomai_project_get_last_workspace(simai_client, httpx_mock):
             (
                 "filter[]",
                 json.dumps(
-                    {"field": "project", "operator": "EQ", "value": project.id},
+                    {"field": "project_id", "operator": "EQ", "value": project.id},
                     separators=(",", ":"),
                 ),
             ),
@@ -323,7 +323,7 @@ def test_geomai_project_get_last_workspace_empty_returns_none(simai_client, http
             (
                 "filter[]",
                 json.dumps(
-                    {"field": "project", "operator": "EQ", "value": project.id},
+                    {"field": "project_id", "operator": "EQ", "value": project.id},
                     separators=(",", ":"),
                 ),
             ),


### PR DESCRIPTION
Fix the field name for `project_id` when retrieving last workspace from a GeomAI project

[sc-39723]